### PR TITLE
Create initial CronJob setup

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -24,7 +24,7 @@ spec:
     periodSeconds: 5
     timeout: 5
     failureThreshold: 3
-  leaderElection: false
+  leaderElection: true
   prometheus:
     enabled: true
     path: /prometheus
@@ -96,6 +96,8 @@ spec:
       value: "https://syfoperson.dev-fss-pub.nais.io"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.dev-fss-pub.nais.io"
+    - name: TOGGLE_JOURNALFORING_CRONJOB_ENABLED
+      value: "true"
     - name: TOGGLE_MQ_SENDING_ENABLED
       value: 'false'
     - name: MQGATEWAY_HOSTNAME

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -24,7 +24,7 @@ spec:
     periodSeconds: 5
     timeout: 5
     failureThreshold: 3
-  leaderElection: false
+  leaderElection: true
   prometheus:
     enabled: true
     path: /prometheus
@@ -96,6 +96,8 @@ spec:
       value: "https://syfoperson.prod-fss-pub.nais.io"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.prod-fss-pub.nais.io"
+    - name: TOGGLE_JOURNALFORING_CRONJOB_ENABLED
+      value: "false"
     - name: TOGGLE_MQ_SENDING_ENABLED
       value: 'false'
     - name: MQGATEWAY_HOSTNAME

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.application.api.authentication.getWellKnown
+import no.nav.syfo.application.api.cronjobModule
 import no.nav.syfo.application.database.applicationDatabase
 import no.nav.syfo.application.database.databaseModule
 import no.nav.syfo.application.mq.MQSender
@@ -60,6 +61,10 @@ fun main() {
                     environment = environment,
                     wellKnownSelvbetjening = getWellKnown(environment.loginserviceIdportenDiscoveryUrl),
                     wellKnownVeileder = getWellKnown(environment.aadDiscoveryUrl),
+                )
+                cronjobModule(
+                    applicationState = applicationState,
+                    environment = environment,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -4,6 +4,7 @@ import io.ktor.application.*
 
 data class Environment(
     val aadDiscoveryUrl: String = getEnvVar("AADDISCOVERY_URL"),
+    val electorPath: String = getEnvVar("ELECTOR_PATH"),
     val loginserviceIdportenDiscoveryUrl: String = getEnvVar("LOGINSERVICE_IDPORTEN_DISCOVERY_URL"),
     val loginserviceIdportenAudience: List<String> = getEnvVar("LOGINSERVICE_IDPORTEN_AUDIENCE").split(","),
     val kafkaBootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP_SERVERS_URL"),
@@ -28,6 +29,7 @@ data class Environment(
     val syfomoteadminUrl: String = getEnvVar("SYFOMOTEADMIN_URL"),
     val syfopersonUrl: String = getEnvVar("SYFOPERSON_URL"),
     val syfotilgangskontrollUrl: String = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
+    val journalforingCronjobEnabled: Boolean = getEnvVar("TOGGLE_JOURNALFORING_CRONJOB_ENABLED").toBoolean(),
     val mqChannelName: String = getEnvVar("MQGATEWAY_CHANNEL_NAME", "DEV.APP.SVRCONN"),
     val mqHostname: String = getEnvVar("MQGATEWAY_HOSTNAME", "localhost"),
     val mqQueueManager: String = getEnvVar("MQGATEWAY_NAME", "QM1"),

--- a/src/main/kotlin/no/nav/syfo/application/api/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/CronjobModule.kt
@@ -1,0 +1,45 @@
+package no.nav.syfo.application.api
+
+import io.ktor.application.*
+import kotlinx.coroutines.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.cronjob.journalforing.DialogmoteVarselJournalforingCronjob
+import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
+
+fun Application.cronjobModule(
+    applicationState: ApplicationState,
+    environment: Environment
+) {
+    val leaderPodClient = LeaderPodClient(
+        environment = environment,
+    )
+    val journalforDialogmoteVarslerCronjob = DialogmoteVarselJournalforingCronjob(
+        applicationState = applicationState,
+        leaderPodClient = leaderPodClient,
+    )
+
+    if (environment.journalforingCronjobEnabled) {
+        createListenerCronjob(
+            applicationState = applicationState,
+        ) {
+            journalforDialogmoteVarslerCronjob.start()
+        }
+    } else {
+        log.info("JournalforingCronjob is not enabled")
+    }
+}
+
+fun Application.createListenerCronjob(
+    applicationState: ApplicationState,
+    action: suspend CoroutineScope.() -> Unit
+): Job = GlobalScope.launch {
+    try {
+        action()
+    } catch (ex: Exception) {
+        log.error("Something went wrong, terminating application", ex)
+    } finally {
+        applicationState.alive = false
+        applicationState.ready = false
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/ObjectMapperConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ObjectMapperConfig.kt
@@ -1,8 +1,6 @@
 package no.nav.syfo.client
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 

--- a/src/main/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
@@ -1,0 +1,62 @@
+package no.nav.syfo.cronjob.journalforing
+
+import kotlinx.coroutines.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+data class JournalforingResult(
+    var updated: Int = 0,
+    var failed: Int = 0,
+)
+
+class DialogmoteVarselJournalforingCronjob(
+    private val applicationState: ApplicationState,
+    private val leaderPodClient: LeaderPodClient,
+) {
+    suspend fun start() = coroutineScope {
+        val (initialDelay, intervalDelay) = delays()
+        log.info("CRONJOB-TRACE: Scheduling start of job: initialDelay: $initialDelay ms, interval: $intervalDelay ms")
+        delay(initialDelay)
+
+        while (applicationState.alive) {
+            val job = launch { run() }
+            delay(intervalDelay)
+            if (job.isActive) {
+                log.warn("CRONJOB-TRACE: Waiting for job to finish")
+                job.join()
+            }
+        }
+        log.info("CRONJOB-TRACE: Ending job")
+    }
+
+    private fun run() {
+        try {
+            if (leaderPodClient.isLeader()) {
+                val resultat = dialogmoteVarselJournalforingJob()
+                log.info("CRONJOB-TRACE: Completed job: failed=${resultat.failed}, updated=${resultat.updated}")
+            } else {
+                log.info("CRONJOB-TRACE: Pod is not leader and will not perform job")
+            }
+        } catch (ex: Exception) {
+            log.error("CRONJOB-TRACE: exception in job. Job will run again after delay.", ex)
+        }
+    }
+
+    private fun dialogmoteVarselJournalforingJob(): JournalforingResult {
+        // TODO: Implement JournaligforingJob
+        return JournalforingResult()
+    }
+
+    private fun delays(): Pair<Long, Long> {
+        // TODO: Set approriate delay durations
+        val initialDelay = Duration.ofMinutes(2).toMillis()
+        val intervalDelay = Duration.ofMinutes(10).toMillis()
+        return Pair(initialDelay, intervalDelay)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DialogmoteVarselJournalforingCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/cronjob/leaderelection/LeaderPodClient.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/leaderelection/LeaderPodClient.kt
@@ -1,0 +1,57 @@
+package no.nav.syfo.cronjob.leaderelection
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.Environment
+import no.nav.syfo.client.configuredJacksonMapper
+import org.slf4j.LoggerFactory
+import java.net.InetAddress
+
+class LeaderPodClient(
+    private val environment: Environment,
+) {
+    private val httpClient = HttpClient(CIO) {}
+
+    private val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    fun isLeader(): Boolean {
+        val electorPath = environment.electorPath
+        try {
+            val electorUrl = getElectorUrl(electorPath)
+            log.debug("Looking for leader at url=$electorUrl")
+            return runBlocking {
+                val response: HttpResponse = httpClient.get(electorUrl) {
+                    accept(ContentType.Text.Plain)
+                }
+                val leaderPodDTO: LeaderPodDTO = objectMapper.readValue(
+                    response.receive<String>()
+                )
+                val hostname: String = InetAddress.getLocalHost().hostName
+
+                if (hostname == leaderPodDTO.name) {
+                    log.debug("Pod with $hostname is the leader")
+                    true
+                } else {
+                    log.debug("Pod with $hostname is not leader, leader is:${leaderPodDTO.name}")
+                    false
+                }
+            }
+        } catch (ex: Exception) {
+            log.error("Exception caught while looking for leader.", ex)
+            return false
+        }
+    }
+
+    private fun getElectorUrl(electorPath: String) = "http://$electorPath"
+
+    companion object {
+        private val log = LoggerFactory.getLogger(LeaderPodClient::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/cronjob/leaderelection/LeaderPodDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/leaderelection/LeaderPodDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.cronjob.leaderelection
+
+data class LeaderPodDTO(
+    val name: String,
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -15,6 +15,7 @@ fun testEnvironment(
     syfotilgangskontrollUrl: String? = null
 ) = Environment(
     aadDiscoveryUrl = "",
+    electorPath = "electorPath",
     loginserviceIdportenDiscoveryUrl = "",
     loginserviceIdportenAudience = listOf("idporten"),
     kafkaBootstrapServers = kafkaBootstrapServers,
@@ -38,6 +39,7 @@ fun testEnvironment(
     syfomoteadminUrl = syfomoteadminUrl ?: "syfomoteadmin",
     syfopersonUrl = syfopersonUrl ?: "syfoperson",
     syfotilgangskontrollUrl = syfotilgangskontrollUrl ?: "tilgangskontroll",
+    journalforingCronjobEnabled = false,
     mqUsername = "mquser",
     mqPassword = "mqpassword",
     mqTredjepartsVarselQueue = "queuename",


### PR DESCRIPTION
Create intiial setup of cronJob that creates a cronjob and the job is only performed by the pod that is the leader.
The cronjob starts after an initial delay and then run periodically according to an interval delay.

Leader election is performed by getting current leader pod from NAIS and comparing it to self.

If an exception is caught in the cronjob, then isAlive and isReady is set to false and the application will restart.