### PR TITLE
Fix dialogmoteTidSted.latest function

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmoteTidSted.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmoteTidSted.kt
@@ -26,4 +26,4 @@ fun DialogmoteTidSted.toDialogmoteTidStedDTO() =
 fun DialogmoteTidSted.passed(): Boolean = this.tid.isBefore(LocalDateTime.now())
 
 fun List<DialogmoteTidSted>.latest() =
-    this.maxByOrNull { it.tid }
+    this.maxByOrNull { it.createdAt }


### PR DESCRIPTION
Latest DialogmoteTidOgSted is the one that has been created most recently, i.e. the one with the max createdAt, not the max tid.