### PR TITLE
Create separate DTO for ArbeidstakerVarselAPI

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/Dialogmote.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/Dialogmote.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.dialogmote.domain
 
 import no.nav.syfo.client.pdfgen.model.*
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
+import no.nav.syfo.varsel.arbeidstaker.domain.ArbeidstakerVarselDTO
 import java.time.LocalDateTime
 import java.util.*
 
@@ -38,6 +39,17 @@ fun Dialogmote.toDialogmoteDTO() =
             it.toDialogmoteTidStedDTO()
         },
     )
+
+fun List<Dialogmote>.toArbeidstakerVarselDTOList(): List<ArbeidstakerVarselDTO> {
+    return this.map { dialogmote ->
+        dialogmote.arbeidstaker.varselList.map {
+            it.toArbeidstakerVarselDTO(
+                dialogmoteTidSted = dialogmote.tidStedList.latest()!!,
+                virksomhetsummer = dialogmote.arbeidsgiver.virksomhetsnummer,
+            )
+        }
+    }.flatten()
+}
 
 fun Dialogmote.toPdfModelAvlysningArbeidstaker() =
     PdfModelAvlysningArbeidstaker(

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidstakerVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidstakerVarsel.kt
@@ -3,7 +3,9 @@ package no.nav.syfo.dialogmote.domain
 import no.nav.syfo.client.dokarkiv.domain.createJournalpostRequest
 import no.nav.syfo.dialogmote.api.domain.DialogmotedeltakerArbeidstakerVarselDTO
 import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.varsel.MotedeltakerVarselType
+import no.nav.syfo.varsel.arbeidstaker.domain.ArbeidstakerVarselDTO
 import no.nav.syfo.varsel.toJournalpostTittel
 import java.time.LocalDateTime
 import java.util.*
@@ -33,6 +35,23 @@ fun DialogmotedeltakerArbeidstakerVarsel.toDialogmotedeltakerArbeidstakerVarselD
         fritekst = this.fritekst,
         document = this.document,
     )
+
+fun DialogmotedeltakerArbeidstakerVarsel.toArbeidstakerVarselDTO(
+    dialogmoteTidSted: DialogmoteTidSted,
+    virksomhetsummer: Virksomhetsnummer,
+) = ArbeidstakerVarselDTO(
+    uuid = this.uuid.toString(),
+    createdAt = this.createdAt,
+    varselType = this.varselType.name,
+    digitalt = this.digitalt,
+    lestDato = this.lestDato,
+    fritekst = this.fritekst,
+    sted = dialogmoteTidSted.sted,
+    tid = dialogmoteTidSted.tid,
+    videoLink = dialogmoteTidSted.videoLink,
+    virksomhetsnummer = virksomhetsummer.value,
+    document = this.document,
+)
 
 fun DialogmotedeltakerArbeidstakerVarsel.toJournalpostRequest(
     personIdent: PersonIdentNumber,

--- a/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
@@ -7,7 +7,7 @@ import io.ktor.routing.*
 import no.nav.syfo.application.api.authentication.personIdent
 import no.nav.syfo.dialogmote.DialogmoteService
 import no.nav.syfo.dialogmote.DialogmotedeltakerService
-import no.nav.syfo.dialogmote.domain.toDialogmoteDTO
+import no.nav.syfo.dialogmote.domain.toArbeidstakerVarselDTOList
 import no.nav.syfo.util.callIdArgument
 import no.nav.syfo.util.getCallId
 import org.slf4j.Logger
@@ -31,12 +31,10 @@ fun Route.registerArbeidstakerVarselApi(
                 val requestPersonIdent = call.personIdent()
                     ?: throw IllegalArgumentException("No PersonIdent found in token")
 
-                val dialogmoteDTOList = dialogmoteService.getDialogmoteList(
-                    personIdentNumber = requestPersonIdent
-                ).map { dialogmote ->
-                    dialogmote.toDialogmoteDTO()
-                }
-                call.respond(dialogmoteDTOList)
+                val arbeidstakerVarselDTOList = dialogmoteService.getDialogmoteList(
+                    personIdentNumber = requestPersonIdent,
+                ).toArbeidstakerVarselDTOList()
+                call.respond(arbeidstakerVarselDTOList)
             } catch (e: IllegalArgumentException) {
                 val illegalArgumentMessage = "Could not retrieve VarselList"
                 log.warn("$illegalArgumentMessage: {}, {}", e.message, callIdArgument(callId))

--- a/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/domain/ArbeidstakerVarselDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/domain/ArbeidstakerVarselDTO.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.varsel.arbeidstaker.domain
+
+import no.nav.syfo.dialogmote.domain.DocumentComponentDTO
+import java.time.LocalDateTime
+
+data class ArbeidstakerVarselDTO(
+    val uuid: String,
+    val createdAt: LocalDateTime,
+    val varselType: String,
+    val digitalt: Boolean,
+    val lestDato: LocalDateTime?,
+    val fritekst: String,
+    val sted: String,
+    val tid: LocalDateTime,
+    val videoLink: String?,
+    val document: List<DocumentComponentDTO>,
+    val virksomhetsnummer: String,
+)

--- a/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
@@ -9,15 +9,13 @@ import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.client.moteplanlegger.domain.*
 import no.nav.syfo.dialogmote.api.dialogmoteApiBasepath
-import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
-import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
-import no.nav.syfo.varsel.MotedeltakerVarselType
 import no.nav.syfo.varsel.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.varsel.arbeidstaker.domain.ArbeidstakerVarselDTO
 import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -104,13 +102,11 @@ class ArbeidstakerVarselApiSpek : Spek({
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                            val dialogmoteList = objectMapper.readValue<List<DialogmoteDTO>>(response.content!!)
+                            val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
 
-                            dialogmoteList.size shouldBeEqualTo 1
+                            arbeidstakerVarselList.size shouldBeEqualTo 1
 
-                            val dialogmoteDTO = dialogmoteList.first()
-
-                            val arbeidstakerVarselDTO = dialogmoteDTO.arbeidstaker.varselList.first()
+                            val arbeidstakerVarselDTO = arbeidstakerVarselList.first()
                             arbeidstakerVarselDTO.shouldNotBeNull()
                             arbeidstakerVarselDTO.digitalt shouldBeEqualTo true
                             arbeidstakerVarselDTO.lestDato.shouldBeNull()
@@ -135,28 +131,15 @@ class ArbeidstakerVarselApiSpek : Spek({
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                            val dialogmoteList = objectMapper.readValue<List<DialogmoteDTO>>(response.content!!)
+                            val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
+                            arbeidstakerVarselList.size shouldBeEqualTo 1
 
-                            dialogmoteList.size shouldBeEqualTo 1
-
-                            val dialogmoteDTO = dialogmoteList.first()
-                            dialogmoteDTO.planlagtMoteUuid shouldBeEqualTo planlagtmoteUUID
-                            dialogmoteDTO.planlagtMoteBekreftetTidspunkt.shouldNotBeNull()
-                            dialogmoteDTO.status shouldBeEqualTo DialogmoteStatus.INNKALT.name
-
-                            dialogmoteDTO.arbeidstaker.personIdent shouldBeEqualTo planlagtMoteDTO?.fnr
-                            val arbeidstakerVarselDTO = dialogmoteDTO.arbeidstaker.varselList.find {
-                                it.varselType == MotedeltakerVarselType.INNKALT.name
-                            }
+                            val arbeidstakerVarselDTO = arbeidstakerVarselList.first()
                             arbeidstakerVarselDTO.shouldNotBeNull()
                             arbeidstakerVarselDTO.digitalt shouldBeEqualTo true
                             arbeidstakerVarselDTO.lestDato.shouldNotBeNull()
-
-                            dialogmoteDTO.arbeidsgiver.virksomhetsnummer shouldBeEqualTo planlagtMoteDTO?.arbeidsgiver()?.orgnummer
-
-                            dialogmoteDTO.tidStedList.size shouldBeEqualTo 1
-                            val dialogmoteTidStedDTO = dialogmoteDTO.tidStedList.first()
-                            dialogmoteTidStedDTO.sted shouldBeEqualTo planlagtMoteDTO?.tidStedValgt()?.sted
+                            arbeidstakerVarselDTO.virksomhetsnummer shouldBeEqualTo planlagtMoteDTO?.arbeidsgiver()?.orgnummer
+                            arbeidstakerVarselDTO.sted shouldBeEqualTo planlagtMoteDTO?.tidStedValgt()?.sted
                             val isTodayBeforeDialogmotetid = LocalDateTime.now().isBefore(planlagtMoteDTO?.tidStedValgt()?.tid)
                             isTodayBeforeDialogmotetid shouldBeEqualTo true
 


### PR DESCRIPTION
Create a new data transfer object for transering information to Arbeidstaker in ArbeidstakerVarselAPI. 
The new DTO contains relevant information from DialogmotedeltakerArbeidstakerVarsel plus information from DialogmoteTidOgSted and the virksomhetsnummer of DialogmotedeltakerArbeidsgiver.