### PR TITLE
Repeatable migration for å styre grants til tabeller

### DIFF
--- a/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
@@ -1,0 +1,1 @@
+grant all on MOTEDELTAKER_ARBEIDSGIVER_VARSEL to cloudsqliamuser;


### PR DESCRIPTION
Lager et repeatable script for å styre tilgang til nye tabeller etter hvert som de lages. 

Scriptet kan oppdateres og flyway vil kjøre det hver gang checksum'en endres.

Scriptet kan evnt. også brukes til å fjerne rettigheter og legge inn nye mer begrensede rettigheter.