### PR TITLE
Create kafka topic for status endring

### DIFF
--- a/.github/workflows/kafka.yaml
+++ b/.github/workflows/kafka.yaml
@@ -1,0 +1,36 @@
+name: kafka
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/kafka.yaml'
+      - '.nais/kafka/**'
+
+jobs:
+  deploy-kafka-dev:
+    name: Deploy Kafka topic to NAIS dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/statusendring.yaml
+          VARS: .nais/kafka/dev.json
+
+  deploy-kafka-prod:
+    name: Deploy Kafka topic to NAIS prod-gcp
+    needs: deploy-kafka-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/kafka/statusendring.yaml
+          VARS: .nais/kafka/prod.json
+

--- a/.nais/kafka/dev.json
+++ b/.nais/kafka/dev.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-dev"
+}

--- a/.nais/kafka/prod.json
+++ b/.nais/kafka/prod.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-prod"
+}

--- a/.nais/kafka/statusendring.yaml
+++ b/.nais/kafka/statusendring.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Statusendringer for innkalte dialogmøte"
+    dcat.data.nav.no/description: >-
+      Topic inneholder alle statusendringer for innkalte dialogmøter.
+      En statusendring kan være en av disse typene: INNKALT, NYTT_TID_STED, AVLYST eller FERDIGSTILT
+  name: isdialogmote-dialogmote-statusendring
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 1
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: isdialogmote
+      access: readwrite

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Creating a docker image should be as simple as `docker build -t isdialogmote .`
 
 ### Cache
 This application uses Redis for caching. Redis is deployed automatically on changes to workflow or config on master branch. For manual deploy, run: `kubectl apply -f .nais/redis-config.yaml` or `kubectl apply -f .nais/redisexporter.yaml`.
+
+### Kafka
+This application produces the following topic(s):
+* isdialogmote-dialogmote-statusendring


### PR DESCRIPTION
- Create Kafka topic with kafkarator(Aiven Kafka) for dialogmote-statusendring for usage in NAV statistikk.
- Create Github action workflow for handling deploy of Kafka topic.
- Update README with a section about kafka.