### PR TITLE
Endrer til liste med tekster i DocumentComponentDTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DocumentComponentDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DocumentComponentDTO.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.dialogmote.domain
 data class DocumentComponentDTO(
     val type: DocumentComponentType,
     val title: String?,
-    val text: String?,
+    val texts: List<String>,
 )
 
 enum class DocumentComponentType {

--- a/src/test/kotlin/no/nav/syfo/dialogmote/PostDialogmoteApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/PostDialogmoteApiSpek.kt
@@ -122,16 +122,19 @@ class PostDialogmoteApiSpek : Spek({
                             arbeidstakerVarselDTO.lestDato.shouldBeNull()
                             arbeidstakerVarselDTO.fritekst shouldBeEqualTo "Ipsum lorum arbeidstaker"
 
-                            arbeidstakerVarselDTO.document.size shouldBeEqualTo 4
+                            arbeidstakerVarselDTO.document.size shouldBeEqualTo 5
                             arbeidstakerVarselDTO.document[0].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
                             arbeidstakerVarselDTO.document[0].title shouldBeEqualTo "Tittel innkalling"
+                            arbeidstakerVarselDTO.document[0].texts shouldBeEqualTo emptyList()
                             arbeidstakerVarselDTO.document[1].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
                             arbeidstakerVarselDTO.document[1].title shouldBeEqualTo "Møtetid:"
-                            arbeidstakerVarselDTO.document[1].text shouldBeEqualTo "5. mai 2021"
+                            arbeidstakerVarselDTO.document[1].texts shouldBeEqualTo listOf("5. mai 2021")
                             arbeidstakerVarselDTO.document[2].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
-                            arbeidstakerVarselDTO.document[2].text shouldBeEqualTo "Brødtekst"
+                            arbeidstakerVarselDTO.document[2].texts shouldBeEqualTo listOf("Brødtekst")
                             arbeidstakerVarselDTO.document[3].type shouldBeEqualTo DocumentComponentType.LINK
-                            arbeidstakerVarselDTO.document[3].text shouldBeEqualTo "https://nav.no/"
+                            arbeidstakerVarselDTO.document[3].texts shouldBeEqualTo listOf("https://nav.no/")
+                            arbeidstakerVarselDTO.document[4].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
+                            arbeidstakerVarselDTO.document[4].texts shouldBeEqualTo listOf("Vennlig hilsen", "NAV Staden", "Kari Saksbehandler")
 
                             dialogmoteDTO.arbeidsgiver.virksomhetsnummer shouldBeEqualTo newDialogmoteDTO.arbeidsgiver.virksomhetsnummer
                             dialogmoteDTO.arbeidsgiver.varselList.size shouldBeEqualTo 1

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
@@ -42,10 +42,31 @@ fun generateMotedeltakerArbeidstakerDTO(
 
 fun generateDocumentComponentList(): List<DocumentComponentDTO> {
     return listOf(
-        DocumentComponentDTO(DocumentComponentType.PARAGRAPH, "Tittel innkalling", null),
-        DocumentComponentDTO(DocumentComponentType.PARAGRAPH, "Møtetid:", "5. mai 2021"),
-        DocumentComponentDTO(DocumentComponentType.PARAGRAPH, null, "Brødtekst"),
-        DocumentComponentDTO(DocumentComponentType.LINK, null, "https://nav.no/"),
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "Tittel innkalling",
+            texts = emptyList(),
+        ),
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "Møtetid:",
+            texts = listOf("5. mai 2021"),
+        ),
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = null,
+            texts = listOf("Brødtekst"),
+        ),
+        DocumentComponentDTO(
+            type = DocumentComponentType.LINK,
+            title = null,
+            texts = listOf("https://nav.no/"),
+        ),
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = null,
+            texts = listOf("Vennlig hilsen", "NAV Staden", "Kari Saksbehandler"),
+        ),
     )
 }
 


### PR DESCRIPTION
Endre til liste med tekster i DocumentComponentDTO for å kunne støtte signaturer og andre tekst-bolker der det er ønske om å ha mindre linjeavstand enn det blir mellom paragrafer.