### PR TITLE
Databasetabeller for referat

### DIFF
--- a/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
@@ -1,1 +1,3 @@
 grant all on MOTEDELTAKER_ARBEIDSGIVER_VARSEL to cloudsqliamuser;
+grant all on MOTE_REFERAT to cloudsqliamuser;
+grant all on MOTEDELTAKER_ANNEN to cloudsqliamuser;

--- a/src/main/resources/db/migration/V4_8__create_table_mote_referat.sql
+++ b/src/main/resources/db/migration/V4_8__create_table_mote_referat.sql
@@ -1,0 +1,27 @@
+CREATE TABLE MOTE_REFERAT (
+	id                       SERIAL             PRIMARY KEY,
+	uuid                     VARCHAR(50)        NOT NULL UNIQUE,
+	created_at               TIMESTAMP          NOT NULL,
+	updated_at               TIMESTAMP          NOT NULL,
+	mote_id                  INTEGER REFERENCES MOTE (id) ON DELETE CASCADE,
+	situasjon                TEXT,
+	konklusjon               TEXT,
+	arbeidstaker_oppgave     TEXT,
+	arbeidsgiver_oppgave     TEXT,
+	veileder_oppgave         TEXT,
+	document                 JSONB NOT NULL DEFAULT '[]'::jsonb
+);
+
+CREATE TABLE MOTEDELTAKER_ANNEN (
+	id                       SERIAL             PRIMARY KEY,
+	uuid                     VARCHAR(50)        NOT NULL UNIQUE,
+	created_at               TIMESTAMP          NOT NULL,
+	updated_at               TIMESTAMP          NOT NULL,
+	mote_referat_id          INTEGER REFERENCES MOTE_REFERAT (id) ON DELETE CASCADE,
+	funksjon                 TEXT NOT NULL,
+	navn                     TEXT NOT NULL
+);
+
+CREATE INDEX IX_MOTE_REFERAT_MOTE_ID ON MOTE_REFERAT (mote_id);
+
+CREATE INDEX IX_MOTEDELTAKER_ANNEN_REFERAT_ID ON MOTEDELTAKER_ANNEN (mote_referat_id);


### PR DESCRIPTION
Dette er ment som et utkast til hvordan referatet representeres i databasen.

Jeg er usikker på om vi trenger flagg for sjekkboksene som er spesifisert i MVP'en - disse styrer bare hvilke standardtekster som blir med i document-dto'en. Vi kunne eventuelt utvide DocumentComponentDTO med et optional key-felt som kan gjøre det enklere for frontend å bestemme hvilke sjekkbokser som ble valgt.