### PR TITLE
Nytt key-felt i DocumentComponentDTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DocumentComponentDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DocumentComponentDTO.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.dialogmote.domain
 
 data class DocumentComponentDTO(
     val type: DocumentComponentType,
+    val key: String? = null,
     val title: String?,
     val texts: List<String>,
 )

--- a/src/test/kotlin/no/nav/syfo/dialogmote/FerdigstillDialogmoteApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/FerdigstillDialogmoteApiSpek.kt
@@ -141,11 +141,14 @@ class FerdigstillDialogmoteApiSpek : Spek({
                             val referat = dialogmoteDTO.referat!!
                             referat.situasjon shouldBeEqualTo "Dette er en beskrivelse av situasjonen"
                             referat.document[0].type shouldBeEqualTo DocumentComponentType.HEADER
-                            referat.document[0].title shouldBeEqualTo "Tittel referat"
-                            referat.document[0].texts shouldBeEqualTo emptyList()
+                            referat.document[0].texts shouldBeEqualTo listOf("Tittel referat")
 
                             referat.document[1].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
                             referat.document[1].texts shouldBeEqualTo listOf("Brødtekst")
+
+                            referat.document[2].type shouldBeEqualTo DocumentComponentType.PARAGRAPH
+                            referat.document[2].key shouldBeEqualTo "Standardtekst"
+                            referat.document[2].texts shouldBeEqualTo listOf("Dette er en standardtekst")
 
                             referat.andreDeltakere.first().funksjon shouldBeEqualTo "Verneombud"
                             referat.andreDeltakere.first().navn shouldBeEqualTo "Tøff Pyjamas"

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
@@ -151,13 +151,19 @@ fun generateReferatComponentList(): List<DocumentComponentDTO> {
     return listOf(
         DocumentComponentDTO(
             type = DocumentComponentType.HEADER,
-            title = "Tittel referat",
-            texts = emptyList(),
+            title = null,
+            texts = listOf("Tittel referat"),
         ),
         DocumentComponentDTO(
             type = DocumentComponentType.PARAGRAPH,
             title = null,
             texts = listOf("Brødtekst"),
+        ),
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            key = "Standardtekst",
+            title = null,
+            texts = listOf("Dette er en standardtekst"),
         ),
     )
 }


### PR DESCRIPTION
For å gjøre det enklere for esyfo-app'ene å vise relevante linker knyttet til standardtekster i referatet, legger vi til et optional key-felt i DocumentComponentDTO - dvs en nøkkel som ikke endrer seg selv om innholdet i standardteksten skulle bli endret.