### PR TITLE
Ikke oppdatere lestdato ved multiple api-kall

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
@@ -50,21 +50,21 @@ fun Route.registerArbeidstakerVarselApi(
 
                 val varselUuid = UUID.fromString(call.parameters[arbeidstakerVarselApiVarselParam])
 
-                val motedeltakerArbeidstakerVarselList = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstakerVarselList(
+                val motedeltakerArbeidstakerVarsel = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstakerVarselList(
                     uuid = varselUuid
-                )
+                ).firstOrNull()
+
                 val referat = dialogmoteService.getReferat(
                     referatUUID = varselUuid
                 )
 
-                if (motedeltakerArbeidstakerVarselList.isEmpty() && referat == null) {
+                if (motedeltakerArbeidstakerVarsel == null && referat == null) {
                     throw IllegalArgumentException("No Varsel found for PersonIdent with uuid=$varselUuid")
                 }
-
                 val motedeltakerArbeidstakerId = if (referat != null) {
                     dialogmoteService.getDialogmote(referat.moteId).arbeidstaker.id
                 } else {
-                    motedeltakerArbeidstakerVarselList.first().motedeltakerArbeidstakerId
+                    motedeltakerArbeidstakerVarsel!!.motedeltakerArbeidstakerId
                 }
 
                 val motedeltakerArbeidstaker = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstakerFromId(
@@ -73,13 +73,14 @@ fun Route.registerArbeidstakerVarselApi(
 
                 val hasAccessToVarsel = motedeltakerArbeidstaker.personIdent == requestPersonIdent
                 if (hasAccessToVarsel) {
-                    if (referat != null) {
+                    if (referat != null && referat.lestDatoArbeidstaker == null) {
                         dialogmotedeltakerService.lesReferatArbeidstaker(
                             personIdentNumber = requestPersonIdent,
                             dialogmotedeltakerArbeidstakerUuid = motedeltakerArbeidstaker.uuid,
                             referatUuid = varselUuid,
                         )
-                    } else {
+                    }
+                    if (motedeltakerArbeidstakerVarsel != null && motedeltakerArbeidstakerVarsel.lestDato == null) {
                         dialogmotedeltakerService.lesDialogmotedeltakerArbeidstakerVarsel(
                             personIdentNumber = requestPersonIdent,
                             dialogmotedeltakerArbeidstakerUuid = motedeltakerArbeidstaker.uuid,

--- a/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
@@ -118,6 +118,7 @@ class ArbeidstakerVarselApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                         }
 
+                        var arbeidstakerVarselDTO: ArbeidstakerVarselDTO?
                         with(
                             handleRequest(HttpMethod.Get, urlArbeidstakerMoterList) {
                                 addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
@@ -128,15 +129,38 @@ class ArbeidstakerVarselApiSpek : Spek({
                             val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
                             arbeidstakerVarselList.size shouldBeEqualTo 1
 
-                            val arbeidstakerVarselDTO = arbeidstakerVarselList.first()
+                            arbeidstakerVarselDTO = arbeidstakerVarselList.firstOrNull()
                             arbeidstakerVarselDTO.shouldNotBeNull()
-                            arbeidstakerVarselDTO.digitalt shouldBeEqualTo true
-                            arbeidstakerVarselDTO.lestDato.shouldNotBeNull()
-                            arbeidstakerVarselDTO.virksomhetsnummer shouldBeEqualTo newDialogmoteDTO.arbeidsgiver.virksomhetsnummer
-                            arbeidstakerVarselDTO.sted shouldBeEqualTo newDialogmoteDTO.tidSted.sted
+                            arbeidstakerVarselDTO!!.digitalt shouldBeEqualTo true
+                            arbeidstakerVarselDTO!!.lestDato.shouldNotBeNull()
+                            arbeidstakerVarselDTO!!.virksomhetsnummer shouldBeEqualTo newDialogmoteDTO.arbeidsgiver.virksomhetsnummer
+                            arbeidstakerVarselDTO!!.sted shouldBeEqualTo newDialogmoteDTO.tidSted.sted
                             val isTodayBeforeDialogmotetid = LocalDateTime.now().isBefore(newDialogmoteDTO.tidSted.tid)
                             isTodayBeforeDialogmotetid shouldBeEqualTo true
 
+                            verify(exactly = 1) { brukernotifikasjonProducer.sendOppgave(any(), any()) }
+                            verify(exactly = 1) { brukernotifikasjonProducer.sendDone(any(), any()) }
+                        }
+                        with(
+                            handleRequest(HttpMethod.Post, urlArbeidstakerVarselUUIDLes) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                        }
+
+                        with(
+                            handleRequest(HttpMethod.Get, urlArbeidstakerMoterList) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
+                            arbeidstakerVarselList.size shouldBeEqualTo 1
+
+                            val arbeidstakerVarselUpdatedDTO = arbeidstakerVarselList.first()
+                            arbeidstakerVarselUpdatedDTO.lestDato shouldBeEqualTo arbeidstakerVarselDTO!!.lestDato
                             verify(exactly = 1) { brukernotifikasjonProducer.sendOppgave(any(), any()) }
                             verify(exactly = 1) { brukernotifikasjonProducer.sendDone(any(), any()) }
                         }
@@ -288,6 +312,7 @@ class ArbeidstakerVarselApiSpek : Spek({
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                         }
+                        var arbeidstakerVarselDTO: ArbeidstakerVarselDTO?
                         with(
                             handleRequest(HttpMethod.Get, arbeidstakerVarselApiPath) {
                                 addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
@@ -297,10 +322,31 @@ class ArbeidstakerVarselApiSpek : Spek({
                             val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
                             arbeidstakerVarselList.size shouldBeEqualTo 6
 
-                            val arbeidstakerVarselDTO = arbeidstakerVarselList.first()
+                            arbeidstakerVarselDTO = arbeidstakerVarselList.firstOrNull()
                             arbeidstakerVarselDTO.shouldNotBeNull()
-                            arbeidstakerVarselDTO.varselType shouldBeEqualTo MotedeltakerVarselType.REFERAT.name
-                            arbeidstakerVarselDTO.lestDato.shouldNotBeNull()
+                            arbeidstakerVarselDTO!!.varselType shouldBeEqualTo MotedeltakerVarselType.REFERAT.name
+                            arbeidstakerVarselDTO!!.lestDato.shouldNotBeNull()
+                        }
+                        with(
+                            handleRequest(HttpMethod.Post, urlReferatUUIDLes) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                        }
+                        with(
+                            handleRequest(HttpMethod.Get, arbeidstakerVarselApiPath) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val arbeidstakerVarselList = objectMapper.readValue<List<ArbeidstakerVarselDTO>>(response.content!!)
+                            arbeidstakerVarselList.size shouldBeEqualTo 6
+
+                            val arbeidstakerVarselUpdatedDTO = arbeidstakerVarselList.firstOrNull()
+                            arbeidstakerVarselUpdatedDTO.shouldNotBeNull()
+                            arbeidstakerVarselUpdatedDTO.varselType shouldBeEqualTo MotedeltakerVarselType.REFERAT.name
+                            arbeidstakerVarselUpdatedDTO.lestDato shouldBeEqualTo arbeidstakerVarselDTO!!.lestDato
                         }
                     }
                 }


### PR DESCRIPTION
Unngå at lestdato oppdateres og nye varsler sendes ut ved multiple kall til api-post-tjenesten for å sette et varsel eller referat som lest.

Kan endre til å lage en feil, men synes i utgangspunktet ikke det er så viktig i dette tilfellet.