### PR TITLE
Unngå kall til syfoperson for veiledere som ikke har tilgang til person

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/tilgang/DialogmoteTilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/tilgang/DialogmoteTilgangService.kt
@@ -16,9 +16,11 @@ class DialogmoteTilgangService(
         callId: String,
     ): Boolean {
         val veilederHasAccessToPerson = veilederTilgangskontrollClient.hasAccess(personIdentNumber, token, callId)
-        val personHasAdressebeskyttelse = adressebeskyttelseClient.hasAdressebeskyttelse(personIdentNumber, token, callId)
-
-        return veilederHasAccessToPerson && !personHasAdressebeskyttelse
+        return if (veilederHasAccessToPerson) {
+            val personHasAdressebeskyttelse =
+                adressebeskyttelseClient.hasAdressebeskyttelse(personIdentNumber, token, callId)
+            !personHasAdressebeskyttelse
+        } else false
     }
 
     suspend fun hasAccessToDialogmotePersonList(


### PR DESCRIPTION
Vi ser en del 403-feil fra syfoperson i loggene til isdialogmote. Tror vi kan få færre forekomster av det ved å unngå å kalle syfoperson for å sjekke adressebeskyttelse hvis vi allerede har funnet ut at veilederen ikke har tilgang til personen.