### PR TITLE
Øke http-timeout og timer for kall til syfoperson-adressebeskyttelse.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -2,11 +2,16 @@ package no.nav.syfo.client
 
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import no.nav.syfo.util.configuredJacksonMapper
 
 fun httpClientDefault() = HttpClient(CIO) {
     install(JsonFeature) {
         serializer = JacksonSerializer(configuredJacksonMapper())
+    }
+    install(HttpTimeout) {
+        requestTimeoutMillis = 120000
+        connectTimeoutMillis = 60000
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/person/PersonMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/person/PersonMetric.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.client.person
 
 import io.prometheus.client.Counter
+import io.prometheus.client.Histogram
 import no.nav.syfo.metric.METRICS_NS
 
 const val CALL_PERSON_BASE = "call_person"
@@ -8,15 +9,21 @@ const val CALL_PERSON_ADRESSEBESKYTTELSE_BASE = "${CALL_PERSON_BASE}_adressebesk
 
 const val CALL_PERSON_ADRESSEBESKYTTELSE_SUCCESS = "${CALL_PERSON_ADRESSEBESKYTTELSE_BASE}_success_count"
 const val CALL_PERSON_ADRESSEBESKYTTELSE_FAIL = "${CALL_PERSON_ADRESSEBESKYTTELSE_BASE}_fail_count"
+const val CALL_PERSON_ADRESSEBESKYTTELSE_TIMER = "${CALL_PERSON_ADRESSEBESKYTTELSE_BASE}_timer"
 val COUNT_CALL_PERSON_ADRESSEBESKYTTELSE_SUCCESS: Counter = Counter.build()
     .namespace(METRICS_NS)
     .name(CALL_PERSON_ADRESSEBESKYTTELSE_SUCCESS)
-    .help("Counts the number of successful calls to Syfoperson - Adressebeskyyttelse")
+    .help("Counts the number of successful calls to Syfoperson - Adressebeskyttelse")
     .register()
 val COUNT_CALL_PERSON_ADRESSEBESKYTTELSE_FAIL: Counter = Counter.build()
     .namespace(METRICS_NS)
     .name(CALL_PERSON_ADRESSEBESKYTTELSE_FAIL)
-    .help("Counts the number of failed calls to Syfoperson - Adressebeksyttelse")
+    .help("Counts the number of failed calls to Syfoperson - Adressebeskyttelse")
+    .register()
+val HISTOGRAM_CALL_PERSON_ADRESSEBESKYTTELSE_TIMER: Histogram = Histogram.build()
+    .namespace(METRICS_NS)
+    .name(CALL_PERSON_ADRESSEBESKYTTELSE_TIMER)
+    .help("Timer for calls to Syfoperson - Adressebeskyttelse")
     .register()
 
 const val CALL_PERSON_KONTAKTINFORMASJON_BASE = "${CALL_PERSON_BASE}_kontaktinformasjon"
@@ -26,12 +33,12 @@ const val CALL_PERSON_KONTAKTINFORMASJON_FAIL = "${CALL_PERSON_KONTAKTINFORMASJO
 val COUNT_CALL_PERSON_KONTAKTINFORMASJON_SUCCESS: Counter = Counter.build()
     .namespace(METRICS_NS)
     .name(CALL_PERSON_KONTAKTINFORMASJON_SUCCESS)
-    .help("Counts the number of successful calls to Syfoperson - Adressebeskyyttelse")
+    .help("Counts the number of successful calls to Syfoperson - Adressebeskyttelse")
     .register()
 val COUNT_CALL_PERSON_KONTAKTINFORMASJON_FAIL: Counter = Counter.build()
     .namespace(METRICS_NS)
     .name(CALL_PERSON_KONTAKTINFORMASJON_FAIL)
-    .help("Counts the number of failed calls to Syfoperson - Adressebeksyttelse")
+    .help("Counts the number of failed calls to Syfoperson - Adressebeskyttelse")
     .register()
 
 const val CALL_PERSON_OPPFOLGINGSTILFELLE_BASE = "${CALL_PERSON_BASE}_oppfolgingstilfelle"


### PR DESCRIPTION
Et nytt forsøk på å løse problemet med sporadiske 500-feil. Lurer på om det skyldes at kall til syfoperson timer ut.