### PR TITLE
Unngå kall til syfoperson for veiledere som ikke har tilgang til person (igjen)

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/tilgang/DialogmoteTilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/tilgang/DialogmoteTilgangService.kt
@@ -42,9 +42,11 @@ class DialogmoteTilgangService(
         token: String,
         callId: String,
     ): Boolean {
-        val kontaktinfo = kontaktinformasjonClient.kontaktinformasjon(personIdentNumber, token, callId)
-        val isDigitalVarselAllowed = kontaktinfo?.kontaktinfo?.get(personIdentNumber.value)?.kanVarsles ?: false
 
-        return hasAccessToDialogmotePerson(personIdentNumber, token, callId) && isDigitalVarselAllowed
+        return if (hasAccessToDialogmotePerson(personIdentNumber, token, callId)) {
+            val kontaktinfo = kontaktinformasjonClient.kontaktinformasjon(personIdentNumber, token, callId)
+            val isDigitalVarselAllowed = kontaktinfo?.kontaktinfo?.get(personIdentNumber.value)?.kanVarsles ?: false
+            isDigitalVarselAllowed
+        } else false
     }
 }


### PR DESCRIPTION
Fant et annet sted der vi gjør kall til syfoperson selv om veileder mangler tilgang til personen.