### PR TITLE
Endepunkt for å hente ut pdf for arbeidstaker-varsel

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotedeltakerService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotedeltakerService.kt
@@ -68,6 +68,11 @@ class DialogmotedeltakerService(
         )
         return pMotedeltakerArbeidsgiver.toDialogmotedeltakerArbeidsgiver(motedeltakerArbeidsgiverVarselList)
     }
+    fun getDialogmotedeltakerArbeidstakerVarselPdf(
+        dialogmotedeltakerArbeidstakerVarselUuid: UUID,
+    ): ByteArray {
+        return database.getMotedeltakerArbeidstakerVarsel(dialogmotedeltakerArbeidstakerVarselUuid).first().pdf
+    }
 
     fun lesDialogmotedeltakerArbeidstakerVarsel(
         personIdentNumber: PersonIdentNumber,
@@ -86,6 +91,12 @@ class DialogmotedeltakerService(
             )
             connection.commit()
         }
+    }
+
+    fun getReferatPdf(
+        referatUuid: UUID,
+    ): ByteArray {
+        return database.getReferat(referatUuid).first().pdf
     }
 
     fun lesReferatArbeidstaker(

--- a/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApi.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.dialogmote.DialogmotedeltakerService
 import no.nav.syfo.dialogmote.domain.toArbeidstakerVarselDTOList
 import no.nav.syfo.util.callIdArgument
 import no.nav.syfo.util.getCallId
+import no.nav.syfo.varsel.arbeidstaker.domain.PdfContent
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -19,6 +20,7 @@ private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
 const val arbeidstakerVarselApiPath = "/api/v1/arbeidstaker/varsel"
 const val arbeidstakerVarselApiVarselParam = "varseluuid"
 const val arbeidstakerVarselApiLesPath = "/les"
+const val arbeidstakerVarselApiPdfPath = "/pdf"
 
 fun Route.registerArbeidstakerVarselApi(
     dialogmoteService: DialogmoteService,
@@ -37,6 +39,59 @@ fun Route.registerArbeidstakerVarselApi(
                 call.respond(arbeidstakerVarselDTOList)
             } catch (e: IllegalArgumentException) {
                 val illegalArgumentMessage = "Could not retrieve VarselList"
+                log.warn("$illegalArgumentMessage: {}, {}", e.message, callIdArgument(callId))
+                call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
+            }
+        }
+
+        get("/{$arbeidstakerVarselApiVarselParam}$arbeidstakerVarselApiPdfPath") {
+            val callId = getCallId()
+            try {
+                val requestPersonIdent = call.personIdent()
+                    ?: throw IllegalArgumentException("No PersonIdent found in token")
+
+                val varselUuid = UUID.fromString(call.parameters[arbeidstakerVarselApiVarselParam])
+
+                val motedeltakerArbeidstakerVarsel = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstakerVarselList(
+                    uuid = varselUuid
+                ).firstOrNull()
+
+                val referat = dialogmoteService.getReferat(
+                    referatUUID = varselUuid
+                )
+
+                if (motedeltakerArbeidstakerVarsel == null && referat == null) {
+                    throw IllegalArgumentException("No Varsel found for PersonIdent with uuid=$varselUuid")
+                }
+                val motedeltakerArbeidstakerId = if (referat != null) {
+                    dialogmoteService.getDialogmote(referat.moteId).arbeidstaker.id
+                } else {
+                    motedeltakerArbeidstakerVarsel!!.motedeltakerArbeidstakerId
+                }
+
+                val motedeltakerArbeidstaker = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstakerFromId(
+                    moteDeltakerArbeidstakerId = motedeltakerArbeidstakerId
+                )
+
+                val hasAccessToVarsel = motedeltakerArbeidstaker.personIdent == requestPersonIdent
+                if (hasAccessToVarsel) {
+                    val pdf = if (referat != null) {
+                        dialogmotedeltakerService.getReferatPdf(
+                            referatUuid = varselUuid,
+                        )
+                    } else { // motedeltakerArbeidstakerVarsel != null
+                        dialogmotedeltakerService.getDialogmotedeltakerArbeidstakerVarselPdf(
+                            dialogmotedeltakerArbeidstakerVarselUuid = varselUuid,
+                        )
+                    }
+                    call.respond(PdfContent(pdf))
+                } else {
+                    val accessDeniedMessage = "Denied access to pdf for Varsel for varselUUID"
+                    log.warn("$accessDeniedMessage, {}", callIdArgument(callId))
+                    call.respond(HttpStatusCode.Forbidden, accessDeniedMessage)
+                }
+            } catch (e: IllegalArgumentException) {
+                val illegalArgumentMessage = "Could not get pdf for Varsel for varselUUID"
                 log.warn("$illegalArgumentMessage: {}, {}", e.message, callIdArgument(callId))
                 call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
             }

--- a/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/domain/PdfContent.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/arbeidstaker/domain/PdfContent.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.varsel.arbeidstaker.domain
+
+import io.ktor.http.*
+import io.ktor.http.content.*
+
+class PdfContent(
+    val pdf: ByteArray,
+    override val contentType: ContentType = ContentType.Application.Pdf
+) : OutgoingContent.ByteArrayContent() {
+    override fun bytes(): ByteArray = pdf
+}

--- a/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/arbeidstaker/ArbeidstakerVarselApiSpek.kt
@@ -348,6 +348,26 @@ class ArbeidstakerVarselApiSpek : Spek({
                             arbeidstakerVarselUpdatedDTO.varselType shouldBeEqualTo MotedeltakerVarselType.REFERAT.name
                             arbeidstakerVarselUpdatedDTO.lestDato shouldBeEqualTo arbeidstakerVarselDTO!!.lestDato
                         }
+                        val urlPdfForInnkallingNedlasting = "$arbeidstakerVarselApiPath/$createdArbeidstakerVarselUUID$arbeidstakerVarselApiPdfPath"
+                        with(
+                            handleRequest(HttpMethod.Get, urlPdfForInnkallingNedlasting) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val pdfContent = response.byteContent!!
+                            pdfContent shouldBeEqualTo externalMockEnvironment.isdialogmotepdfgenMock.pdfInnkallingArbeidstaker
+                        }
+                        val urlPdfForReferatNedlasting = "$arbeidstakerVarselApiPath/$createdReferatArbeidstakerVarselUUID$arbeidstakerVarselApiPdfPath"
+                        with(
+                            handleRequest(HttpMethod.Get, urlPdfForReferatNedlasting) {
+                                addHeader(Authorization, bearerHeader(validTokenSelvbetjening))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val pdfContent = response.byteContent!!
+                            pdfContent shouldBeEqualTo externalMockEnvironment.isdialogmotepdfgenMock.pdfReferat
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Her er et forslag til det endepunktet for å hente pdf vi snakket om. I første omgang skal det brukes for å hente pdf for referat, men det er så lite ekstra som skal til for å gjøre det generelt - så det som er foreslått her kan brukes til å hente pdf også for innkalling, avlysning og endring av tid/sted.