### PR TITLE
Forbedrer tester for API for arbeidstaker

### DIFF
--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.domain.*
 
 object UserConstants {
     val ARBEIDSTAKER_FNR = PersonIdentNumber("12345678912")
+    val ARBEIDSTAKER_ANNEN_FNR = PersonIdentNumber("12345678913")
     val ARBEIDSTAKER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "1"))
     val ARBEIDSTAKER_NO_JOURNALFORING = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "3"))
     val ARBEIDSTAKER_ADRESSEBESKYTTET = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "6"))


### PR DESCRIPTION
Legger til tester som sjekker at http-status blir Forbidden dersom api-kall har token for en annen arbeidstaker enn den som er relatert til dialogmøtet.