### PR TITLE
Fjerne http timeout

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -13,10 +13,6 @@ fun httpClientDefault() = HttpClient(CIO) {
     install(JsonFeature) {
         serializer = JacksonSerializer(configuredJacksonMapper())
     }
-    install(HttpTimeout) {
-        requestTimeoutMillis = 120000
-        connectTimeoutMillis = 60000
-    }
 }
 
 val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {


### PR DESCRIPTION
Fjerne timeout som ble lagt til i et førsøk på å løse sporadiske 500-feil (hadde ingen effekt)