### PR TITLE
Add explicit logging if DigitalVarsel is not allowed

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/person/kontaktinfo/DigitalKontaktinfoBolk.kt
+++ b/src/main/kotlin/no/nav/syfo/client/person/kontaktinfo/DigitalKontaktinfoBolk.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.person.kontaktinfo
 
+import no.nav.syfo.domain.PersonIdentNumber
 import java.io.Serializable
 
 data class DigitalKontaktinfoBolk(
@@ -18,3 +19,7 @@ data class DigitalKontaktinfo(
 data class Feil(
     val melding: String
 ) : Serializable
+
+fun Map<String, DigitalKontaktinfo>.isDigitalVarselEnabled(
+    personIdentNumber: PersonIdentNumber,
+) = this[personIdentNumber.value]?.kanVarsles ?: false

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/v1/DialogmoteActionsApi.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/v1/DialogmoteActionsApi.kt
@@ -12,7 +12,7 @@ import no.nav.syfo.dialogmote.tilgang.DialogmoteTilgangService
 import no.nav.syfo.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.UUID
+import java.util.*
 
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
 
@@ -38,7 +38,7 @@ fun Route.registerDialogmoteActionsApi(
 
                 val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-                if (dialogmoteTilgangService.hasAccessToDialogmoteInnkalling(dialogmote.arbeidstaker.personIdent, token, callId)) {
+                if (dialogmoteTilgangService.hasAccessToDialogmotePersonWithDigitalVarselEnabled(dialogmote.arbeidstaker.personIdent, token, callId)) {
                     val success = dialogmoteService.avlysMoteinnkalling(
                         callId = callId,
                         dialogmote = dialogmote,
@@ -52,7 +52,6 @@ fun Route.registerDialogmoteActionsApi(
                     }
                 } else {
                     val accessDeniedMessage = "Denied Veileder access to Avlys Dialogmote for moteUUID"
-                    log.warn("$accessDeniedMessage, {}", callIdArgument(callId))
                     call.respond(HttpStatusCode.Forbidden, accessDeniedMessage)
                 }
             } catch (e: IllegalArgumentException) {
@@ -75,7 +74,7 @@ fun Route.registerDialogmoteActionsApi(
 
                 val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-                if (dialogmoteTilgangService.hasAccessToDialogmoteInnkalling(dialogmote.arbeidstaker.personIdent, token, callId)) {
+                if (dialogmoteTilgangService.hasAccessToDialogmotePersonWithDigitalVarselEnabled(dialogmote.arbeidstaker.personIdent, token, callId)) {
                     val success = dialogmoteService.nyttMoteinnkallingTidSted(
                         callId = callId,
                         dialogmote = dialogmote,
@@ -89,7 +88,6 @@ fun Route.registerDialogmoteActionsApi(
                     }
                 } else {
                     val accessDeniedMessage = "Denied Veileder access to create NewDialogmoteTidSted for moteUUID"
-                    log.warn("$accessDeniedMessage, {}", callIdArgument(callId))
                     call.respond(HttpStatusCode.Forbidden, accessDeniedMessage)
                 }
             } catch (e: IllegalArgumentException) {
@@ -111,7 +109,7 @@ fun Route.registerDialogmoteActionsApi(
 
                 val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-                if (dialogmoteTilgangService.hasAccessToDialogmoteInnkalling(dialogmote.arbeidstaker.personIdent, token, callId)) {
+                if (dialogmoteTilgangService.hasAccessToDialogmotePersonWithDigitalVarselEnabled(dialogmote.arbeidstaker.personIdent, token, callId)) {
                     val success = dialogmoteService.ferdigstillMote(
                         callId = callId,
                         dialogmote = dialogmote,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/v1/DialogmoteApi.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/v1/DialogmoteApi.kt
@@ -66,7 +66,7 @@ fun Route.registerDialogmoteApi(
 
                 val personidentNumber = PersonIdentNumber(newDialogmoteDTO.arbeidstaker.personIdent)
 
-                if (dialogmoteTilgangService.hasAccessToDialogmoteInnkalling(personidentNumber, token, callId)) {
+                if (dialogmoteTilgangService.hasAccessToDialogmotePersonWithDigitalVarselEnabled(personidentNumber, token, callId)) {
                     val created = dialogmoteService.createMoteinnkalling(
                         newDialogmoteDTO = newDialogmoteDTO,
                         token = token,
@@ -79,7 +79,6 @@ fun Route.registerDialogmoteApi(
                     }
                 } else {
                     val accessDeniedMessage = "Denied Veileder access to creating new Dialogmote"
-                    log.warn("$accessDeniedMessage, {}", callIdArgument(callId))
                     call.respond(HttpStatusCode.Forbidden, accessDeniedMessage)
                 }
             } catch (e: IllegalArgumentException) {


### PR DESCRIPTION
Make it easier to find the cause of denied access to updating og creating a Dialogmote. The log message is written as an error because this situation should not occur in production as long as DialogmoteInnkalling is not available for persons that only cannot receive digital notifications.