### PR TITLE
Tilpasser servicemelding som sendes via MQ

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -95,8 +95,6 @@ spec:
       value: "38e07d31-659d-4595-939a-f18dce3446c5"
     - name: DIALOGMOTE_ARBEIDSTAKER_URL
       value: "https://tjenester-q1.nav.no/dialogmote"
-    - name: DIALOGMOTE_ARBEIDSGIVER_URL
-      value: "https://tjenester-q1.nav.no/dialogmotearbeidsgiver"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.dev-fss-pub.nais.io"
     - name: MODIASYFOREST_URL
@@ -116,7 +114,7 @@ spec:
     - name: TOGGLE_JOURNALFORING_CRONJOB_ENABLED
       value: "true"
     - name: TOGGLE_MQ_SENDING_ENABLED
-      value: 'false'
+      value: 'true'
     - name: MQGATEWAY_HOSTNAME
       value: b27apvl220.preprod.local
     - name: MQGATEWAY_PORT
@@ -127,4 +125,5 @@ spec:
       value: Q1_ISDIALOGMOTE
     - name: TREDJEPARTSVARSEL_QUEUENAME
       value: QA.Q1_VARSELPRODUKSJON.BEST_SRVMLD_M_KONTAKT
+
 

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -95,8 +95,6 @@ spec:
       value: "9b4e07a3-4f4c-4bab-b866-87f62dff480d"
     - name: DIALOGMOTE_ARBEIDSTAKER_URL
       value: "https://tjenester.nav.no/dialogmote"
-    - name: DIALOGMOTE_ARBEIDSGIVER_URL
-      value: "https://tjenester.nav.no/dialogmotearbeidsgiver"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.prod-fss-pub.nais.io"
     - name: MODIASYFOREST_URL

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -35,7 +35,6 @@ data class Environment(
     val sidecarInitialDelay: Long = getEnvVar("SIDECAR_INITIAL_DELAY", "30000").toLong(),
     val loginserviceClientId: String = getEnvVar("LOGINSERVICE_CLIENT_ID"),
     val dialogmoteArbeidstakerUrl: String = getEnvVar("DIALOGMOTE_ARBEIDSTAKER_URL"),
-    val dialogmoteArbeidsgiverUrl: String = getEnvVar("DIALOGMOTE_ARBEIDSGIVER_URL"),
     val dokarkivUrl: String = getEnvVar("DOKARKIV_URL"),
     val isdialogmotepdfgenUrl: String = "http://isdialogmotepdfgen",
     val modiasyforestUrl: String = getEnvVar("MODIASYFOREST_URL"),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -117,7 +117,6 @@ fun Application.apiModule(
     )
 
     val narmesteLederVarselService = NarmesteLederVarselService(
-        env = environment,
         mqSender = mqSender
     )
 

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.brev.narmesteleder
 
 import no.nav.melding.virksomhet.servicemeldingmedkontaktinformasjon.v1.servicemeldingmedkontaktinformasjon.*
-import no.nav.syfo.application.Environment
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.client.narmesteleder.NarmesteLederDTO
 import no.nav.syfo.dialogmote.domain.MotedeltakerVarselType
@@ -12,18 +11,20 @@ import javax.xml.bind.JAXBContext
 import javax.xml.bind.Marshaller
 
 class NarmesteLederVarselService(
-    private val env: Environment,
     private val mqSender: MQSenderInterface
 ) {
     fun sendVarsel(
         createdAt: LocalDateTime,
+        moteTidspunkt: LocalDateTime,
         narmesteLeder: NarmesteLederDTO,
         varseltype: MotedeltakerVarselType
     ) {
         val parameterListe: MutableList<WSParameter> = ArrayList()
         parameterListe.add(createParameter("createdAt", createdAt.format(DateTimeFormatter.ISO_DATE_TIME)))
-        parameterListe.add(createParameter("navn", narmesteLeder.organisasjonsnavn))
-        parameterListe.add(createParameter("url", env.dialogmoteArbeidstakerUrl))
+        parameterListe.add(createParameter("navn", narmesteLeder.navn))
+        parameterListe.add(
+            createParameter("tidspunkt", moteTidspunkt.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")))
+        )
 
         val melding = opprettServiceMelding(narmesteLeder, varseltype, parameterListe)
         val xmlString = marshallServiceMelding(ObjectFactory().createServicemelding(melding))

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -172,6 +172,7 @@ class DialogmoteService(
                     fritekstArbeidsgiver = newDialogmote.arbeidsgiver.fritekstInnkalling.orEmpty(),
                     documentArbeidstaker = newDialogmoteDTO.arbeidstaker.innkalling,
                     documentArbeidsgiver = newDialogmoteDTO.arbeidsgiver.innkalling,
+                    moteTidspunkt = newDialogmoteDTO.tidSted.tid,
                 )
 
                 connection.commit()
@@ -239,7 +240,8 @@ class DialogmoteService(
                         fritekstArbeidstaker = avlysDialogmote.arbeidstaker.begrunnelse,
                         fritekstArbeidsgiver = avlysDialogmote.arbeidsgiver.begrunnelse,
                         documentArbeidstaker = avlysDialogmote.arbeidstaker.avlysning,
-                        documentArbeidsgiver = avlysDialogmote.arbeidsgiver.avlysning
+                        documentArbeidsgiver = avlysDialogmote.arbeidsgiver.avlysning,
+                        moteTidspunkt = dialogmote.tidStedList.latest()!!.tid
                     )
                 }
                 connection.commit()
@@ -310,6 +312,7 @@ class DialogmoteService(
                     fritekstArbeidsgiver = endreDialogmoteTidSted.arbeidsgiver.begrunnelse,
                     documentArbeidstaker = endreDialogmoteTidSted.arbeidstaker.endringsdokument,
                     documentArbeidsgiver = endreDialogmoteTidSted.arbeidsgiver.endringsdokument,
+                    moteTidspunkt = endreDialogmoteTidSted.tid,
                 )
 
                 connection.commit()
@@ -332,6 +335,7 @@ class DialogmoteService(
         fritekstArbeidsgiver: String = "",
         documentArbeidstaker: List<DocumentComponentDTO> = emptyList(),
         documentArbeidsgiver: List<DocumentComponentDTO> = emptyList(),
+        moteTidspunkt: LocalDateTime,
     ) {
         val (_, varselArbeidstakerId) = connection.createMotedeltakerVarselArbeidstaker(
             commit = false,
@@ -362,6 +366,7 @@ class DialogmoteService(
         )
         narmesteLederVarselService.sendVarsel(
             createdAt = now,
+            moteTidspunkt = moteTidspunkt,
             narmesteLeder = narmesteLeder,
             varseltype = varselType
         )
@@ -432,6 +437,7 @@ class DialogmoteService(
             )
             narmesteLederVarselService.sendVarsel(
                 createdAt = now,
+                moteTidspunkt = dialogmote.tidStedList.latest()!!.tid,
                 narmesteLeder = narmesteLeder,
                 varseltype = MotedeltakerVarselType.REFERAT,
             )

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -46,7 +46,6 @@ fun testEnvironment(
     isdialogmoteDbPassword = "password",
     loginserviceClientId = "123456789",
     dialogmoteArbeidstakerUrl = "https://www.nav.no/dialogmote",
-    dialogmoteArbeidsgiverUrl = "https://www.nav.no/dialogmote",
     dokarkivUrl = dokarkivUrl,
     isdialogmotepdfgenUrl = isdialogmotepdfgenUrl ?: "http://isdialogmotepdfgen",
     modiasyforestUrl = modiasyforestUrl ?: "modiasyforest",

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/ModiasyforestMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/ModiasyforestMock.kt
@@ -19,11 +19,12 @@ import no.nav.syfo.util.getPersonIdentHeader
 import java.time.LocalDate
 
 val narmesteLederDTOVirksomhetHasLeader = NarmesteLederDTO(
-    navn = "",
+    navn = "narmesteLederNavn",
     aktoerId = "",
     fomDato = LocalDate.now().minusDays(10),
     orgnummer = VIRKSOMHETSNUMMER_HAS_NARMESTELEDER.value,
     organisasjonsnavn = "",
+    epost = "narmesteLederNavn@gmail.com"
 )
 
 class ModiasyforestMock {


### PR DESCRIPTION
Varslingsnøklene er nå definert i varseladmin med tilhørende epost-maler. Parameterene som sendes med er forenklet i forhold til det som brukes fra syfomoteadmin, så de vi trenger nå er navn på nærmeste leder og tidspunkt for dialogmøte.