### PR TITLE
Ingress som skal gjøre det mulig å nå isdialogmote fra sbs

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -40,6 +40,7 @@ spec:
       memory: 384Mi
   ingresses:
     - "https://isdialogmote.intern.nav.no"
+    - "https://isdialogmote.nav.no"
   gcp:
     sqlInstances:
       - type: POSTGRES_12


### PR DESCRIPTION
https://doc.nais.io/clusters/migrating-to-gcp/#how-do-i-reach-an-application-found-on-gcp-from-my-application-on-premises