### PR TITLE
Api og tester for møtedeltaker-behandler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -98,11 +98,13 @@ class DialogmoteService(
     ): Dialogmote {
         val motedeltakerArbeidstaker = dialogmotedeltakerService.getDialogmoteDeltakerArbeidstaker(pDialogmote.id)
         val motedeltakerArbeidsgiver = dialogmotedeltakerService.getDialogmoteDeltakerArbeidsgiver(pDialogmote.id)
+        val motedeltakerBehandler = dialogmotedeltakerService.getDialogmoteDeltakerBehandler(pDialogmote.id)
         val dialogmoteTidStedList = getDialogmoteTidStedList(pDialogmote.id)
         val referat = getReferatForMote(pDialogmote.uuid)
         return pDialogmote.toDialogmote(
             dialogmotedeltakerArbeidstaker = motedeltakerArbeidstaker,
             dialogmotedeltakerArbeidsgiver = motedeltakerArbeidsgiver,
+            dialogmotedeltakerBehandler = motedeltakerBehandler,
             dialogmoteTidStedList = dialogmoteTidStedList,
             referat = referat,
         )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotedeltakerService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotedeltakerService.kt
@@ -3,12 +3,8 @@ package no.nav.syfo.dialogmote
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.brev.arbeidstaker.ArbeidstakerVarselService
 import no.nav.syfo.dialogmote.database.*
-import no.nav.syfo.dialogmote.database.domain.toDialogmotedeltakerArbeidsgiver
-import no.nav.syfo.dialogmote.database.domain.toDialogmotedeltakerArbeidstaker
-import no.nav.syfo.dialogmote.domain.DialogmotedeltakerArbeidsgiver
-import no.nav.syfo.dialogmote.domain.DialogmotedeltakerArbeidsgiverVarsel
-import no.nav.syfo.dialogmote.domain.DialogmotedeltakerArbeidstaker
-import no.nav.syfo.dialogmote.domain.DialogmotedeltakerArbeidstakerVarsel
+import no.nav.syfo.dialogmote.database.domain.*
+import no.nav.syfo.dialogmote.domain.*
 import no.nav.syfo.domain.PersonIdentNumber
 import java.util.UUID
 
@@ -58,6 +54,14 @@ class DialogmotedeltakerService(
         }
     }
 
+    fun getDialogmoteDeltakerBehandlerVarselList(
+        motedeltakerBehandlerId: Int,
+    ): List<DialogmotedeltakerBehandlerVarsel> {
+        return database.getMotedeltakerBehandlerVarsel(motedeltakerBehandlerId).map {
+            it.toDialogmotedeltakerBehandler()
+        }
+    }
+
     fun getDialogmoteDeltakerArbeidstakerById(
         moteDeltakerArbeidstakerId: Int,
     ): DialogmotedeltakerArbeidstaker {
@@ -76,6 +80,17 @@ class DialogmotedeltakerService(
             pMotedeltakerArbeidsgiver.id
         )
         return pMotedeltakerArbeidsgiver.toDialogmotedeltakerArbeidsgiver(motedeltakerArbeidsgiverVarselList)
+    }
+
+    fun getDialogmoteDeltakerBehandler(
+        moteId: Int,
+    ): DialogmotedeltakerBehandler? {
+        return database.getMoteDeltakerBehandler(moteId)?.let {
+            val motedeltakerBehandlerVarselList = getDialogmoteDeltakerBehandlerVarselList(
+                it.id
+            )
+            it.toDialogmotedeltakerBehandler(motedeltakerBehandlerVarselList)
+        }
     }
 
     fun getDialogmoteDeltakerArbeidsgiverById(

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/DialogmoteDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/DialogmoteDTO.kt
@@ -12,6 +12,7 @@ data class DialogmoteDTO(
     val tildeltEnhet: String,
     val arbeidstaker: DialogmotedeltakerArbeidstakerDTO,
     val arbeidsgiver: DialogmotedeltakerArbeidsgiverDTO,
+    val behandler: DialogmotedeltakerBehandlerDTO?,
     val sted: String,
     val tid: LocalDateTime,
     val videoLink: String?,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/NewDialogmoteDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/NewDialogmoteDTO.kt
@@ -11,6 +11,7 @@ data class NewDialogmoteDTO(
     val tildeltEnhet: String,
     val arbeidstaker: NewDialogmotedeltakerArbeidstakerDTO,
     val arbeidsgiver: NewDialogmotedeltakerArbeidsgiverDTO,
+    val behandler: NewDialogmotedeltakerBehandlerDTO? = null,
     val tidSted: NewDialogmoteTidStedDTO,
 )
 
@@ -23,6 +24,13 @@ data class NewDialogmotedeltakerArbeidstakerDTO(
 data class NewDialogmotedeltakerArbeidsgiverDTO(
     val virksomhetsnummer: String,
     val fritekstInnkalling: String?,
+    val innkalling: List<DocumentComponentDTO>,
+)
+
+data class NewDialogmotedeltakerBehandlerDTO(
+    val behandlerRef: String,
+    val behandlerNavn: String,
+    val behandlerKontor: String,
     val innkalling: List<DocumentComponentDTO>,
 )
 
@@ -50,10 +58,17 @@ fun NewDialogmoteDTO.toNewDialogmote(
             virksomhetsnummer = Virksomhetsnummer(this.arbeidsgiver.virksomhetsnummer),
             fritekstInnkalling = this.arbeidsgiver.fritekstInnkalling,
         ),
+        behandler = this.behandler?.let {
+            NewDialogmotedeltakerBehandler(
+                behandlerRef = it.behandlerRef,
+                behandlerNavn = it.behandlerNavn,
+                behandlerKontor = it.behandlerKontor,
+            )
+        },
         tidSted = NewDialogmoteTidSted(
             sted = tidSted.sted,
             tid = tidSted.tid,
             videoLink = tidSted.videoLink,
-        )
+        ),
     )
 }

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
@@ -124,6 +124,13 @@ fun Connection.createNewDialogmoteWithReferences(
         moteId = moteId,
         newDialogmotedeltakerArbeidsgiver = newDialogmote.arbeidsgiver,
     )
+    newDialogmote.behandler?.let {
+        this.createMotedeltakerBehandler(
+            commit = false,
+            moteId = moteId,
+            newDialogmotedeltakerBehandler = it,
+        )
+    }
 
     if (commit) {
         this.commit()

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselQuery.kt
@@ -1,0 +1,97 @@
+package no.nav.syfo.dialogmote.database
+
+import com.fasterxml.jackson.core.type.TypeReference
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.database.toList
+import no.nav.syfo.dialogmote.database.domain.PMotedeltakerBehandlerVarsel
+import no.nav.syfo.dialogmote.domain.DocumentComponentDTO
+import no.nav.syfo.dialogmote.domain.MotedeltakerVarselType
+import no.nav.syfo.util.configuredJacksonMapper
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+
+const val queryCreateMotedeltakerVarselBehandler =
+    """
+    INSERT INTO MOTEDELTAKER_BEHANDLER_VARSEL (
+        id,
+        uuid,
+        created_at,
+        updated_at,
+        motedeltaker_behandler_id,
+        varseltype,
+        pdf,
+        status, 
+        document) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?::jsonb) RETURNING id
+    """
+
+private val mapper = configuredJacksonMapper()
+
+fun Connection.createMotedeltakerVarselBehandler(
+    commit: Boolean = true,
+    motedeltakerBehandlerId: Int,
+    status: String,
+    varselType: MotedeltakerVarselType,
+    pdf: ByteArray,
+    document: List<DocumentComponentDTO>,
+): Pair<Int, UUID> {
+    val now = Timestamp.from(Instant.now())
+
+    val motedeltakerBehandlerVarselUuid = UUID.randomUUID()
+    val motedeltakerBehandlerVarselIdList = this.prepareStatement(queryCreateMotedeltakerVarselBehandler).use {
+        it.setString(1, motedeltakerBehandlerVarselUuid.toString())
+        it.setTimestamp(2, now)
+        it.setTimestamp(3, now)
+        it.setInt(4, motedeltakerBehandlerId)
+        it.setString(5, varselType.name)
+        it.setBytes(6, pdf)
+        it.setString(7, status)
+        it.setObject(8, mapper.writeValueAsString(document))
+        it.executeQuery().toList { getInt("id") }
+    }
+
+    if (motedeltakerBehandlerVarselIdList.size != 1) {
+        throw SQLException("Creating MotedeltakerVarselBehandler failed, no rows affected.")
+    }
+
+    if (commit) {
+        this.commit()
+    }
+
+    return Pair(motedeltakerBehandlerVarselIdList.first(), motedeltakerBehandlerVarselUuid)
+}
+
+const val queryGetMotedeltakerBehandlerVarselForMotedeltaker =
+    """
+        SELECT *
+        FROM MOTEDELTAKER_BEHANDLER_VARSEL
+        WHERE motedeltaker_behandler_id = ?
+        ORDER BY created_at DESC
+    """
+
+fun DatabaseInterface.getMotedeltakerBehandlerVarsel(
+    motedeltakerBehandlerId: Int
+): List<PMotedeltakerBehandlerVarsel> {
+    return this.connection.use { connection ->
+        connection.prepareStatement(queryGetMotedeltakerBehandlerVarselForMotedeltaker).use {
+            it.setInt(1, motedeltakerBehandlerId)
+            it.executeQuery().toList { toPMotedeltakerBehandlerVarsel() }
+        }
+    }
+}
+
+fun ResultSet.toPMotedeltakerBehandlerVarsel(): PMotedeltakerBehandlerVarsel =
+    PMotedeltakerBehandlerVarsel(
+        id = getInt("id"),
+        uuid = UUID.fromString(getString("uuid")),
+        createdAt = getTimestamp("created_at").toLocalDateTime(),
+        updatedAt = getTimestamp("updated_at").toLocalDateTime(),
+        motedeltakerBehandlerId = getInt("motedeltaker_behandler_id"),
+        varselType = MotedeltakerVarselType.valueOf(getString("varseltype")),
+        pdf = getBytes("pdf"),
+        status = getString("status"),
+        document = mapper.readValue(getString("document"), object : TypeReference<List<DocumentComponentDTO>>() {}),
+    )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerQuery.kt
@@ -156,39 +156,14 @@ const val queryGetMotedeltakerBehandlerForMote =
         WHERE mote_id = ?
     """
 
-fun DatabaseInterface.getMoteDeltakerBehandler(moteId: Int): PMotedeltakerBehandler {
+fun DatabaseInterface.getMoteDeltakerBehandler(moteId: Int): PMotedeltakerBehandler? {
     val pMotedeltakerBehandlerList = this.connection.use { connection ->
         connection.prepareStatement(queryGetMotedeltakerBehandlerForMote).use {
             it.setInt(1, moteId)
             it.executeQuery().toList { toPMotedeltakerBehandler() }
         }
     }
-    pMotedeltakerBehandlerList.assertThatExactlyOneElement(
-        errorMessageIfEmpty = "No motedeltakerBehandler found for moteId with id $moteId",
-        errorMessageIfMoreThanOne = "More than one motedeltakerBehandler found for motedeltakerId with id $moteId",
-    )
-    return pMotedeltakerBehandlerList.first()
-}
-
-const val queryGetMotedeltakerBehandlerForMoteById =
-    """
-        SELECT *
-        FROM MOTEDELTAKER_BEHANDLER
-        WHERE id = ?
-    """
-
-fun DatabaseInterface.getMoteDeltakerBehandlerById(moteDeltakerBehandlerId: Int): PMotedeltakerBehandler {
-    val pMotedeltakerBehandlerList = this.connection.use { connection ->
-        connection.prepareStatement(queryGetMotedeltakerBehandlerForMoteById).use {
-            it.setInt(1, moteDeltakerBehandlerId)
-            it.executeQuery().toList { toPMotedeltakerBehandler() }
-        }
-    }
-    pMotedeltakerBehandlerList.assertThatExactlyOneElement(
-        errorMessageIfEmpty = "No motedeltakerBehandler found for id  $moteDeltakerBehandlerId",
-        errorMessageIfMoreThanOne = "More than one motedeltakerBehandler found for motedeltakerId $moteDeltakerBehandlerId",
-    )
-    return pMotedeltakerBehandlerList.first()
+    return pMotedeltakerBehandlerList.firstOrNull()
 }
 
 fun ResultSet.toPMotedeltakerBehandler(): PMotedeltakerBehandler =

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/domain/PMote.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/domain/PMote.kt
@@ -18,6 +18,7 @@ data class PDialogmote(
 fun PDialogmote.toDialogmote(
     dialogmotedeltakerArbeidstaker: DialogmotedeltakerArbeidstaker,
     dialogmotedeltakerArbeidsgiver: DialogmotedeltakerArbeidsgiver,
+    dialogmotedeltakerBehandler: DialogmotedeltakerBehandler?,
     dialogmoteTidStedList: List<DialogmoteTidSted>,
     referat: Referat?,
 ): Dialogmote =
@@ -32,6 +33,7 @@ fun PDialogmote.toDialogmote(
         tildeltEnhet = this.tildeltEnhet,
         arbeidstaker = dialogmotedeltakerArbeidstaker,
         arbeidsgiver = dialogmotedeltakerArbeidsgiver,
+        behandler = dialogmotedeltakerBehandler,
         tidStedList = dialogmoteTidStedList,
         referat = referat,
     )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/Dialogmote.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/Dialogmote.kt
@@ -17,6 +17,7 @@ data class Dialogmote(
     val tildeltEnhet: String,
     val arbeidstaker: DialogmotedeltakerArbeidstaker,
     val arbeidsgiver: DialogmotedeltakerArbeidsgiver,
+    val behandler: DialogmotedeltakerBehandler?,
     val tidStedList: List<DialogmoteTidSted>,
     val referat: Referat?,
 )
@@ -33,6 +34,7 @@ fun Dialogmote.toDialogmoteDTO(): DialogmoteDTO {
         tildeltEnhet = this.tildeltEnhet,
         arbeidstaker = this.arbeidstaker.toDialogmotedeltakerArbeidstakerDTO(),
         arbeidsgiver = this.arbeidsgiver.toDialogmotedeltakerArbeidsgiverDTO(),
+        behandler = this.behandler?.toDialogmotedeltakerBehandlerDTO(),
         sted = dialogmoteTidSted.sted,
         tid = dialogmoteTidSted.tid,
         videoLink = dialogmoteTidSted.videoLink,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/NewDialogmote.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/NewDialogmote.kt
@@ -11,6 +11,7 @@ data class NewDialogmote(
     val tildeltEnhet: String,
     val arbeidstaker: NewDialogmotedeltakerArbeidstaker,
     val arbeidsgiver: NewDialogmotedeltakerArbeidsgiver,
+    val behandler: NewDialogmotedeltakerBehandler? = null,
     val tidSted: NewDialogmoteTidSted,
 )
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -20,6 +20,10 @@ object UserConstants {
     val ENHET_NR = EnhetNr("1000")
     val ENHET_NR_NO_ACCESS = EnhetNr(ENHET_NR.value.replace("1", "2"))
 
+    val BEHANDLER_REF = "behref"
+    val BEHANDLER_NAVN = "Navn Lege"
+    val BEHANDLER_KONTOR = "Legekontoret"
+
     const val PERSON_TLF = "12345678"
     const val PERSON_EMAIL = "test@nav.no"
     const val PERSON_FORNAVN = "ULLEN"

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
@@ -5,6 +5,9 @@ import no.nav.syfo.dialogmote.domain.DocumentComponentDTO
 import no.nav.syfo.dialogmote.domain.DocumentComponentType
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.UserConstants.BEHANDLER_KONTOR
+import no.nav.syfo.testhelper.UserConstants.BEHANDLER_NAVN
+import no.nav.syfo.testhelper.UserConstants.BEHANDLER_REF
 import no.nav.syfo.testhelper.UserConstants.VIRKSOMHETSNUMMER_HAS_NARMESTELEDER
 import java.time.LocalDateTime
 
@@ -103,6 +106,13 @@ fun generateMotedeltakerArbeidsgiverDTO(
     innkalling = emptyList(),
 )
 
+fun generateMotedeltakerBehandlerDTO() = NewDialogmotedeltakerBehandlerDTO(
+    behandlerRef = BEHANDLER_REF,
+    behandlerNavn = BEHANDLER_NAVN,
+    behandlerKontor = BEHANDLER_KONTOR,
+    innkalling = emptyList(),
+)
+
 fun generateMotedeltakerArbeidsgiverDTOMissingValues() = NewDialogmotedeltakerArbeidsgiverDTO(
     virksomhetsnummer = VIRKSOMHETSNUMMER_HAS_NARMESTELEDER.value,
     fritekstInnkalling = null,
@@ -131,6 +141,18 @@ fun generateNewDialogmoteDTOWithMissingValues(
         arbeidstaker = generateMotedeltakerArbeidstakerDTOMissingValues(personIdentNumber),
         arbeidsgiver = generateMotedeltakerArbeidsgiverDTOMissingValues(),
         tidSted = generateNewDialogmoteTidStedDTONoVideoLink()
+    )
+}
+
+fun generateNewDialogmoteDTOWithBehandler(
+    personIdentNumber: PersonIdentNumber
+): NewDialogmoteDTO {
+    return NewDialogmoteDTO(
+        tildeltEnhet = UserConstants.ENHET_NR.value,
+        arbeidstaker = generateMotedeltakerArbeidstakerDTO(personIdentNumber),
+        arbeidsgiver = generateMotedeltakerArbeidsgiverDTO(),
+        behandler = generateMotedeltakerBehandlerDTO(),
+        tidSted = generateNewDialogmoteTidStedDTONoVideoLink(),
     )
 }
 


### PR DESCRIPTION
Med dette skal det være mulig å lagre en behandler knyttet til et møte og hente den ut igjen i veileder-api'et.

Må jobbe videre med varsler.