### PR TITLE
Validerer at avlysning/endring har behandler når dialogmøte har med behandler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -214,6 +214,10 @@ class DialogmoteService(
         if (dialogmote.status == DialogmoteStatus.AVLYST) {
             throw RuntimeException("Failed to Avlys Dialogmote: already Avlyst")
         }
+        if (dialogmote.behandler != null && avlysDialogmote.behandler == null) {
+            throw RuntimeException("Failed to Avlys Dialogmote: missing behandler")
+        }
+
         val pdfAvlysningArbeidstaker = pdfGenClient.pdfAvlysning(
             callId = callId,
             documentComponentDTOList = avlysDialogmote.arbeidstaker.avlysning,
@@ -297,6 +301,10 @@ class DialogmoteService(
         if (dialogmote.status == DialogmoteStatus.AVLYST) {
             throw RuntimeException("Failed to change tid/sted, already Avlyst")
         }
+        if (dialogmote.behandler != null && endreDialogmoteTidSted.behandler == null) {
+            throw RuntimeException("Failed to change tid/sted: missing behandler")
+        }
+
         val pdfEndringArbeidstaker = pdfGenClient.pdfEndringTidSted(
             callId = callId,
             documentComponentDTOList = endreDialogmoteTidSted.arbeidstaker.endringsdokument

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmoteDTOGenerator.kt
@@ -24,6 +24,13 @@ fun generateAvlysDialogmoteDTO() =
         behandler = generateAvlysningDTO(),
     )
 
+fun generateAvlysDialogmoteDTONoBehandler() =
+    AvlysDialogmoteDTO(
+        arbeidstaker = generateAvlysningDTO(),
+        arbeidsgiver = generateAvlysningDTO(),
+        behandler = null
+    )
+
 fun generateNewDialogmoteTidStedDTO(
     sted: String,
     dato: LocalDateTime,


### PR DESCRIPTION
Koden senere i løypa antar at dersom møtet har behandler så har vi med behandler på avlysning/endring og krasjer med NPE hvis ikke. Legger til validering for å gi bedre feilmelding og unngå at varsler potensielt blir sendt ut før det krasjer.