### PR TITLE
Convert exceptions to ConflictException

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/exception/ConflictException.kt
+++ b/src/main/kotlin/no/nav/syfo/application/exception/ConflictException.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.application.exception
+
+class ConflictException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.dialogmote
 
 import no.nav.syfo.application.api.authentication.getNAVIdentFromToken
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.exception.ConflictException
 import no.nav.syfo.brev.arbeidstaker.ArbeidstakerVarselService
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.narmesteleder.NarmesteLederVarselService
@@ -210,10 +211,10 @@ class DialogmoteService(
         token: String,
     ): Boolean {
         if (dialogmote.status == DialogmoteStatus.FERDIGSTILT) {
-            throw RuntimeException("Failed to Avlys Dialogmote: already Ferdigstilt")
+            throw ConflictException("Failed to Avlys Dialogmote: already Ferdigstilt")
         }
         if (dialogmote.status == DialogmoteStatus.AVLYST) {
-            throw RuntimeException("Failed to Avlys Dialogmote: already Avlyst")
+            throw ConflictException("Failed to Avlys Dialogmote: already Avlyst")
         }
         if (dialogmote.behandler != null && avlysDialogmote.behandler == null) {
             throw RuntimeException("Failed to Avlys Dialogmote: missing behandler")
@@ -298,10 +299,10 @@ class DialogmoteService(
         token: String,
     ): Boolean {
         if (dialogmote.status == DialogmoteStatus.FERDIGSTILT) {
-            throw RuntimeException("Failed to change tid/sted, already Ferdigstilt")
+            throw ConflictException("Failed to change tid/sted, already Ferdigstilt")
         }
         if (dialogmote.status == DialogmoteStatus.AVLYST) {
-            throw RuntimeException("Failed to change tid/sted, already Avlyst")
+            throw ConflictException("Failed to change tid/sted, already Avlyst")
         }
         if (dialogmote.behandler != null && endreDialogmoteTidSted.behandler == null) {
             throw RuntimeException("Failed to change tid/sted: missing behandler")
@@ -498,10 +499,10 @@ class DialogmoteService(
         token: String,
     ): Boolean {
         if (dialogmote.status == DialogmoteStatus.FERDIGSTILT) {
-            throw RuntimeException("Failed to Ferdigstille Dialogmote, already Ferdigstilt")
+            throw ConflictException("Failed to Ferdigstille Dialogmote, already Ferdigstilt")
         }
         if (dialogmote.status == DialogmoteStatus.AVLYST) {
-            throw RuntimeException("Failed to Ferdigstille Dialogmote, already Avlyst")
+            throw ConflictException("Failed to Ferdigstille Dialogmote, already Avlyst")
         }
 
         val narmesteLeder = narmesteLederClient.activeLeder(

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/AvlysDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/AvlysDialogmoteApiV2Spek.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
 import io.mockk.*
+import no.nav.syfo.application.exception.ConflictException
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
@@ -177,7 +178,7 @@ class AvlysDialogmoteApiV2Spek : Spek({
                             }
                         }
 
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDAvlys) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                                 addHeader(Authorization, bearerHeader(validToken))
@@ -188,7 +189,7 @@ class AvlysDialogmoteApiV2Spek : Spek({
                         val urlMoteUUIDFerdigstill =
                             "$dialogmoteApiV2Basepath/$createdDialogmoteUUID$dialogmoteApiMoteFerdigstillPath"
                         val newReferatDTO = generateNewReferatDTO()
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDFerdigstill) {
                                 addHeader(Authorization, bearerHeader(validToken))
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -199,7 +200,7 @@ class AvlysDialogmoteApiV2Spek : Spek({
                         val urlMoteUUIDPostTidSted =
                             "$dialogmoteApiV2Basepath/$createdDialogmoteUUID$dialogmoteApiMoteTidStedPath"
                         val endreTidStedDialogMoteDto = generateEndreDialogmoteTidStedDTO()
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDPostTidSted) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                                 addHeader(Authorization, bearerHeader(validToken))

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
 import io.mockk.*
+import no.nav.syfo.application.exception.ConflictException
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
@@ -179,7 +180,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                             }
                         }
 
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDFerdigstill) {
                                 addHeader(Authorization, bearerHeader(validToken))
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -190,7 +191,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                         val urlMoteUUIDAvlys =
                             "$dialogmoteApiV2Basepath/$createdDialogmoteUUID$dialogmoteApiMoteAvlysPath"
                         val avlysDialogMoteDto = generateAvlysDialogmoteDTO()
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDAvlys) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                                 addHeader(Authorization, bearerHeader(validToken))
@@ -201,7 +202,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                         val urlMoteUUIDPostTidSted =
                             "$dialogmoteApiV2Basepath/$createdDialogmoteUUID$dialogmoteApiMoteTidStedPath"
                         val endreTidStedDialogMoteDto = generateEndreDialogmoteTidStedDTO()
-                        assertThrows(RuntimeException::class.java) {
+                        assertThrows(ConflictException::class.java) {
                             handleRequest(HttpMethod.Post, urlMoteUUIDPostTidSted) {
                                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                                 addHeader(Authorization, bearerHeader(validToken))


### PR DESCRIPTION
A conflict can occur if multiple users arre trying to change the state of the same Dialogmote at the same tid. In case of such a conflict, throw a ConflictException instead of a generic RuntimeException, and return a http 409 indicating a conflict in the state of the accessed Dialogmote. Then the consuming application can update its state accordingly.