### PR TITLE
Egen varseltype for endret referat

### DIFF
--- a/src/main/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerVarselService.kt
@@ -39,7 +39,7 @@ class ArbeidstakerVarselService(
             MotedeltakerVarselType.NYTT_TID_STED -> {
                 "Du har mottatt et brev om endret dialogmøte"
             }
-            MotedeltakerVarselType.REFERAT -> {
+            MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> {
                 "Du har mottatt et referat fra dialogmøte"
             }
         }

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
@@ -52,7 +52,7 @@ class NarmesteLederVarselService(
             MotedeltakerVarselType.INNKALT -> NarmesteLederVarselType.NARMESTE_LEDER_MOTE_INNKALT
             MotedeltakerVarselType.AVLYST -> NarmesteLederVarselType.NARMESTE_LEDER_MOTE_AVLYST
             MotedeltakerVarselType.NYTT_TID_STED -> NarmesteLederVarselType.NARMESTE_LEDER_MOTE_NYTID
-            MotedeltakerVarselType.REFERAT -> NarmesteLederVarselType.NARMESTE_LEDER_REFERAT
+            MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> NarmesteLederVarselType.NARMESTE_LEDER_REFERAT
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/client/altinn/AltinnMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/client/altinn/AltinnMelding.kt
@@ -125,7 +125,7 @@ private fun toMessageTitle(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> TITTEL_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> TITTEL_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> TITTEL_AVLYST
-        MotedeltakerVarselType.REFERAT -> TITTEL_REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> TITTEL_REFERAT
     }
 }
 
@@ -138,7 +138,7 @@ private fun toFilename(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> FILNAVN_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> FILNAVN_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> FILNAVN_AVLYST
-        MotedeltakerVarselType.REFERAT -> FILNAVN_REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> FILNAVN_REFERAT
     }
 }
 
@@ -147,7 +147,7 @@ private fun toMessageBody(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> BODY_KREVER_HANDLING
         MotedeltakerVarselType.NYTT_TID_STED -> BODY_KREVER_HANDLING
         MotedeltakerVarselType.AVLYST -> BODY_FERDIGSTILL
-        MotedeltakerVarselType.REFERAT -> BODY_FERDIGSTILL
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> BODY_FERDIGSTILL
     }
 }
 
@@ -156,7 +156,7 @@ private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> EMAIL_TITTEL_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
-        MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> EMAIL_TITTEL_REFERAT
     }
 }
 
@@ -165,7 +165,7 @@ private fun toEmailBody(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> EMAIL_BODY_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_BODY_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> EMAIL_BODY_AVLYST
-        MotedeltakerVarselType.REFERAT -> EMAIL_BODY_REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> EMAIL_BODY_REFERAT
     }
 }
 
@@ -174,6 +174,6 @@ private fun toSMSBody(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.INNKALT -> SMS_BODY_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> SMS_BODY_AVLYST
-        MotedeltakerVarselType.REFERAT -> SMS_BODY_REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> SMS_BODY_REFERAT
     }
 }

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -733,7 +733,7 @@ class DialogmoteService(
 
             varselService.sendVarsel(
                 tidspunktForVarsel = LocalDateTime.now(),
-                varselType = MotedeltakerVarselType.REFERAT,
+                varselType = MotedeltakerVarselType.REFERAT_ENDRET,
                 moteTidspunkt = dialogmote.tidStedList.latest()!!.tid,
                 isDigitalVarselEnabledForArbeidstaker = digitalVarsling,
                 arbeidstakerPersonIdent = dialogmote.arbeidstaker.personIdent,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/MotedeltakerVarselType.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/MotedeltakerVarselType.kt
@@ -8,6 +8,7 @@ enum class MotedeltakerVarselType {
     INNKALT,
     NYTT_TID_STED,
     REFERAT,
+    REFERAT_ENDRET,
 }
 
 fun MotedeltakerVarselType.toJournalpostTittel(): String {
@@ -21,7 +22,7 @@ fun MotedeltakerVarselType.toJournalpostTittel(): String {
         MotedeltakerVarselType.NYTT_TID_STED -> {
             "Endring av tid og sted for innkalt dialogmøte"
         }
-        MotedeltakerVarselType.REFERAT -> {
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> {
             "Referat fra dialogmøte"
         }
     }
@@ -49,7 +50,7 @@ fun MotedeltakerVarselType.toBrevkodeType(
                 DialogmoteDeltakerType.ARBEIDSGIVER -> BrevkodeType.DIALOGMOTE_ENDRING_TID_STED_AG
                 DialogmoteDeltakerType.BEHANDLER -> BrevkodeType.DIALOGMOTE_ENDRING_TID_STED_BEH
             }
-        MotedeltakerVarselType.REFERAT ->
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET ->
             when (dialogmoteDeltakerType) {
                 DialogmoteDeltakerType.ARBEIDSTAKER -> BrevkodeType.DIALOGMOTE_REFERAT_AT
                 DialogmoteDeltakerType.ARBEIDSGIVER -> BrevkodeType.DIALOGMOTE_REFERAT_AG
@@ -63,7 +64,7 @@ fun MotedeltakerVarselType.getDialogMeldingType(): DialogmeldingType {
         MotedeltakerVarselType.INNKALT -> DialogmeldingType.DIALOG_FORESPORSEL
         MotedeltakerVarselType.NYTT_TID_STED -> DialogmeldingType.DIALOG_FORESPORSEL
         MotedeltakerVarselType.AVLYST -> DialogmeldingType.DIALOG_NOTAT
-        MotedeltakerVarselType.REFERAT -> DialogmeldingType.DIALOG_NOTAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> DialogmeldingType.DIALOG_NOTAT
     }
 }
 
@@ -72,7 +73,7 @@ fun MotedeltakerVarselType.getDialogMeldingKode(): DialogmeldingKode {
         MotedeltakerVarselType.INNKALT -> DialogmeldingKode.INNKALLING
         MotedeltakerVarselType.NYTT_TID_STED -> DialogmeldingKode.TIDSTED
         MotedeltakerVarselType.AVLYST -> DialogmeldingKode.AVLYST
-        MotedeltakerVarselType.REFERAT -> DialogmeldingKode.REFERAT
+        MotedeltakerVarselType.REFERAT, MotedeltakerVarselType.REFERAT_ENDRET -> DialogmeldingKode.REFERAT
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/Referat.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/Referat.kt
@@ -147,7 +147,7 @@ fun Referat.toArbeidstakerBrevDTO(
     uuid = uuid.toString(),
     deltakerUuid = deltakerUuid.toString(),
     createdAt = updatedAt,
-    brevType = MotedeltakerVarselType.REFERAT.name,
+    brevType = this.getMotedeltakerVarselType().name,
     digitalt = digitalt,
     lestDato = lestDatoArbeidstaker,
     fritekst = konklusjon,
@@ -167,7 +167,7 @@ fun Referat.toNarmesteLederBrevDTO(
     uuid = this.uuid.toString(),
     deltakerUuid = deltakerUuid.toString(),
     createdAt = this.updatedAt,
-    brevType = MotedeltakerVarselType.REFERAT.name,
+    brevType = this.getMotedeltakerVarselType().name,
     lestDato = this.lestDatoArbeidsgiver,
     fritekst = konklusjon,
     sted = dialogmoteTidSted.sted,
@@ -177,3 +177,6 @@ fun Referat.toNarmesteLederBrevDTO(
     document = this.document,
     svar = null,
 )
+
+private fun Referat.getMotedeltakerVarselType() =
+    if (begrunnelseEndring == null) MotedeltakerVarselType.REFERAT else MotedeltakerVarselType.REFERAT_ENDRET

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
@@ -333,7 +333,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
-                            verify(exactly = 1) { mqSenderMock.sendMQMessage(MotedeltakerVarselType.REFERAT, any()) }
+                            verify(exactly = 1) { mqSenderMock.sendMQMessage(MotedeltakerVarselType.REFERAT_ENDRET, any()) }
                         }
 
                         with(


### PR DESCRIPTION
Motivasjonen for denne endringen er å legge til rette for at logikken i esyfo-frontend'en skal bli enklere. I andre sammenhenger mappes varseltypen REFERAT_ENDRET på samme måte som REFERAT.