### PR TITLE
Journalføre dokumenter i samme rekkefølge som de er opprettet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerArbeidsgiverVarselQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerArbeidsgiverVarselQuery.kt
@@ -134,6 +134,7 @@ const val queryGetMotedeltakerArbeidsgiverVarselWithoutJournalpost =
         SELECT *
         FROM MOTEDELTAKER_ARBEIDSGIVER_VARSEL
         WHERE journalpost_id IS NULL
+        ORDER BY created_at ASC
         LIMIT 20
     """
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerArbeidstakerVarselQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerArbeidstakerVarselQuery.kt
@@ -109,6 +109,7 @@ const val queryGetMotedeltakerArbeidstakerVarselWithoutJournalpost =
         SELECT *
         FROM MOTEDELTAKER_ARBEIDSTAKER_VARSEL
         WHERE journalpost_id IS NULL
+        ORDER BY created_at ASC
         LIMIT 20
     """
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselQuery.kt
@@ -89,6 +89,7 @@ const val queryGetMotedeltakerBehandlerVarselWithoutJournalpost =
         SELECT *
         FROM MOTEDELTAKER_BEHANDLER_VARSEL
         WHERE journalpost_id IS NULL
+        ORDER BY created_at ASC
         LIMIT 20
     """
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/ReferatQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/ReferatQuery.kt
@@ -292,6 +292,7 @@ const val queryGetFerdigstilteReferatWithoutJournalpostArbeidstaker =
         FROM MOTE INNER JOIN MOTE_REFERAT ON (MOTE.ID = MOTE_REFERAT.MOTE_ID)
                   INNER JOIN MOTEDELTAKER_ARBEIDSTAKER ON (MOTE.ID = MOTEDELTAKER_ARBEIDSTAKER.MOTE_ID) 
         WHERE MOTE_REFERAT.journalpost_id IS NULL AND MOTE_REFERAT.ferdigstilt = true
+        ORDER BY MOTE_REFERAT.created_at ASC
         LIMIT 20
     """
 
@@ -311,6 +312,7 @@ const val queryGetFerdigstilteReferatWithoutJournalpostArbeidsgiver =
         FROM MOTE INNER JOIN MOTE_REFERAT ON (MOTE.ID = MOTE_REFERAT.MOTE_ID)
                   INNER JOIN MOTEDELTAKER_ARBEIDSGIVER ON (MOTE.ID = MOTEDELTAKER_ARBEIDSGIVER.MOTE_ID) 
         WHERE MOTE_REFERAT.journalpost_ag_id IS NULL AND MOTE_REFERAT.ferdigstilt = true
+        ORDER BY MOTE_REFERAT.created_at ASC
         LIMIT 20
     """
 
@@ -330,6 +332,7 @@ const val queryGetFerdigstilteReferatWithoutJournalpostBehandler =
         FROM MOTE INNER JOIN MOTE_REFERAT ON (MOTE.ID = MOTE_REFERAT.MOTE_ID)
                   INNER JOIN MOTEDELTAKER_BEHANDLER ON (MOTE.ID = MOTEDELTAKER_BEHANDLER.MOTE_ID) 
         WHERE MOTE_REFERAT.journalpost_beh_id IS NULL AND MOTE_REFERAT.ferdigstilt = true
+        ORDER BY MOTE_REFERAT.created_at ASC
         LIMIT 20
     """
 


### PR DESCRIPTION
Så noen eksempler i preprod der dokumenter ble journalført i en annen rekkefølge enn de er opprettet i isdialogmote, og det kan gjøre oversikten i Gosys forvirrende.