### PR TITLE
Send varsel to new Dine Sykmeldte topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This application produces the following topic(s):
 
 * isdialogmote-dialogmote-statusendring
 * isdialogmelding-behandler-dialogmelding-bestilling
+* teamsykmelding.dinesykmeldte-hendelser-v2
 
 This application consumes the following topic(s):
 

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -18,6 +18,9 @@ import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.kafkaBrukernotifikasjonP
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.*
 import no.nav.syfo.client.altinn.createPort
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.kafkaDineSykmeldteVarselProducerConfig
+import no.nav.syfo.brev.narmesteleder.domain.DineSykmeldteHendelse
 import no.nav.syfo.cronjob.cronjobModule
 import no.nav.syfo.dialogmelding.DialogmeldingService
 import no.nav.syfo.dialogmelding.kafka.DialogmeldingConsumerService
@@ -43,6 +46,13 @@ fun main() {
         kafkaProducerBeskjed = KafkaProducer<NokkelInput, BeskjedInput>(kafkaBrukernotifikasjonProducerProperties),
         kafkaProducerOppgave = KafkaProducer<NokkelInput, OppgaveInput>(kafkaBrukernotifikasjonProducerProperties),
         kafkaProducerDone = KafkaProducer<NokkelInput, DoneInput>(kafkaBrukernotifikasjonProducerProperties),
+    )
+    val dineSykmeldteVarselProducer = DineSykmeldteVarselProducer(
+        kafkaProducerVarsel = KafkaProducer<String, DineSykmeldteHendelse>(
+            kafkaDineSykmeldteVarselProducerConfig(
+                environment.kafka
+            )
+        ),
     )
     val behandlerDialogmeldingProducer = BehandlerDialogmeldingProducer(
         kafkaProducerBehandlerDialogmeldingBestilling = KafkaProducer<String, KafkaBehandlerDialogmeldingDTO>(
@@ -84,6 +94,7 @@ fun main() {
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
                 behandlerVarselService = behandlerVarselService,
                 database = applicationDatabase,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSender = mqSender,
                 environment = environment,
                 wellKnownSelvbetjening = getWellKnown(environment.loginserviceIdportenDiscoveryUrl),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.brev.arbeidstaker.registerArbeidstakerBrevApi
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.narmesteleder.NarmesteLederAccessService
 import no.nav.syfo.brev.narmesteleder.NarmesteLederVarselService
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.brev.narmesteleder.registerNarmestelederBrevApi
 import no.nav.syfo.client.altinn.AltinnClient
 import no.nav.syfo.client.azuread.AzureAdV2Client
@@ -36,6 +37,7 @@ fun Application.apiModule(
     brukernotifikasjonProducer: BrukernotifikasjonProducer,
     behandlerVarselService: BehandlerVarselService,
     database: DatabaseInterface,
+    dineSykmeldteVarselProducer: DineSykmeldteVarselProducer,
     mqSender: MQSenderInterface,
     environment: Environment,
     wellKnownSelvbetjening: WellKnown,
@@ -116,6 +118,7 @@ fun Application.apiModule(
 
     val narmesteLederVarselService = NarmesteLederVarselService(
         mqSender = mqSender,
+        dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
     )
 
     val dialogmotedeltakerService = DialogmotedeltakerService(

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselService.kt
@@ -62,7 +62,7 @@ class NarmesteLederVarselService(
             ferdigstillHendelse = null
         )
 
-        dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(UUID.randomUUID().toString(), dineSykmeldteHendelse)
+        dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(dineSykmeldteHendelse.id, dineSykmeldteHendelse)
     }
 
     private fun opprettServiceMelding(

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselType.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederVarselType.kt
@@ -6,3 +6,10 @@ enum class NarmesteLederVarselType(val id: String) {
     NARMESTE_LEDER_MOTE_NYTID("syfoDialogmoteNytid"),
     NARMESTE_LEDER_REFERAT("syfoDialogmoteReferat"),
 }
+
+enum class DineSykmeldteOppgavetype {
+    DIALOGMOTE_INNKALLING,
+    DIALOGMOTE_AVLYSNING,
+    DIALOGMOTE_ENDRING,
+    DIALOGMOTE_REFERAT,
+}

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/dinesykmeldte/DineSykmeldteVarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/dinesykmeldte/DineSykmeldteVarselProducer.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.brev.narmesteleder.dinesykmeldte
+
+import no.nav.syfo.brev.narmesteleder.domain.DineSykmeldteHendelse
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+
+const val DINESYKMELDTE_HENDELSE_TOPIC = "teamsykmelding.dinesykmeldte-hendelser-v2"
+
+class DineSykmeldteVarselProducer(
+    private val kafkaProducerVarsel: KafkaProducer<String, DineSykmeldteHendelse>,
+) {
+    fun sendDineSykmeldteVarsel(
+        uuid: String,
+        dineSykmeldteHendelse: DineSykmeldteHendelse,
+    ) {
+        try {
+            kafkaProducerVarsel.send(
+                ProducerRecord(
+                    DINESYKMELDTE_HENDELSE_TOPIC,
+                    uuid,
+                    dineSykmeldteHendelse,
+                )
+            ).get()
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to send varsel with uuid {}: ${e.message}", uuid)
+            throw e
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DineSykmeldteVarselProducer::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/dinesykmeldte/KafkaDineSykmeldteVarselProducerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/dinesykmeldte/KafkaDineSykmeldteVarselProducerConfig.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.brev.narmesteleder.dinesykmeldte
+
+import no.nav.syfo.application.ApplicationEnvironmentKafka
+import no.nav.syfo.application.kafka.JacksonKafkaSerializer
+import no.nav.syfo.application.kafka.commonKafkaAivenProducerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+import java.util.*
+
+fun kafkaDineSykmeldteVarselProducerConfig(
+    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenProducerConfig(applicationEnvironmentKafka))
+        this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.canonicalName
+        this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaSerializer::class.java.canonicalName
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/brev/narmesteleder/domain/DineSykmeldteVarselDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/narmesteleder/domain/DineSykmeldteVarselDTO.kt
@@ -1,0 +1,23 @@
+package no.nav.syfo.brev.narmesteleder.domain
+
+import java.time.OffsetDateTime
+
+data class DineSykmeldteHendelse(
+    val id: String,
+    val opprettHendelse: OpprettHendelse?,
+    val ferdigstillHendelse: FerdigstillHendelse?
+)
+
+data class OpprettHendelse(
+    val ansattFnr: String,
+    val orgnummer: String,
+    val oppgavetype: String,
+    val lenke: String?,
+    val tekst: String?,
+    val timestamp: OffsetDateTime,
+    val utlopstidspunkt: OffsetDateTime?
+)
+
+data class FerdigstillHendelse(
+    val timestamp: OffsetDateTime
+)

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/MotedeltakerVarselType.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/MotedeltakerVarselType.kt
@@ -27,6 +27,23 @@ fun MotedeltakerVarselType.toJournalpostTittel(): String {
     }
 }
 
+fun MotedeltakerVarselType.toDineSykmeldteVarselTekst(): String {
+    return when (this) {
+        MotedeltakerVarselType.AVLYST -> {
+            "Avlysning av dialogmøte"
+        }
+        MotedeltakerVarselType.INNKALT -> {
+            "Innkalling til dialogmøte"
+        }
+        MotedeltakerVarselType.NYTT_TID_STED -> {
+            "Endring av dialogmøte"
+        }
+        MotedeltakerVarselType.REFERAT -> {
+            "Referat fra dialogmøte"
+        }
+    }
+}
+
 fun MotedeltakerVarselType.toBrevkodeType(
     dialogmoteDeltakerType: DialogmoteDeltakerType,
 ): BrevkodeType {

--- a/src/test/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerBrevApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerBrevApiSpek.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.arbeidstaker.domain.ArbeidstakerBrevDTO
 import no.nav.syfo.brev.arbeidstaker.domain.ArbeidstakerResponsDTO
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.api.v2.*
 import no.nav.syfo.dialogmote.domain.*
@@ -41,11 +42,15 @@ class ArbeidstakerBrevApiSpek : Spek({
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
             justRun { brukernotifikasjonProducer.sendDone(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>(relaxed = true)
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederBrevSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederBrevSpek.kt
@@ -8,6 +8,7 @@ import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.arbeidstaker.domain.ArbeidstakerResponsDTO
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.brev.narmesteleder.domain.NarmesteLederBrevDTO
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.api.v2.*
@@ -40,11 +41,15 @@ object NarmesteLederBrevSpek : Spek({
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
             justRun { brukernotifikasjonProducer.sendDone(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>(relaxed = true)
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobSpek.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.azuread.AzureAdV2Client
 import no.nav.syfo.client.dokarkiv.DokarkivClient
 import no.nav.syfo.client.ereg.EregClient
@@ -47,6 +48,9 @@ class DialogmoteVarselJournalforingCronjobSpek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
@@ -61,6 +65,7 @@ class DialogmoteVarselJournalforingCronjobSpek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/journalpostdistribusjon/DialogmoteJournalpostDistribusjonCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/journalpostdistribusjon/DialogmoteJournalpostDistribusjonCronjobSpek.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.azuread.AzureAdV2Client
 import no.nav.syfo.client.journalpostdistribusjon.JournalpostdistribusjonClient
 import no.nav.syfo.dialogmote.DialogmotedeltakerVarselJournalpostService
@@ -39,12 +40,16 @@ class DialogmoteJournalpostDistribusjonCronjobSpek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringCronjobSpek.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.api.v2.*
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
@@ -37,6 +38,9 @@ class PublishDialogmoteStatusEndringCronjobSpek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val behandlerDialogmeldingProducer = mockk<BehandlerDialogmeldingProducer>()
             justRun { behandlerDialogmeldingProducer.sendDialogmelding(dialogmelding = any()) }
 
@@ -55,6 +59,7 @@ class PublishDialogmoteStatusEndringCronjobSpek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/DialogmeldingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/DialogmeldingServiceSpek.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmelding.domain.ForesporselType
 import no.nav.syfo.dialogmelding.domain.SvarType
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
@@ -34,6 +35,7 @@ class DialogmeldingServiceSpek : Spek({
             val externalMockEnvironment = ExternalMockEnvironment.getInstance()
             val database = externalMockEnvironment.database
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
             val behandlerDialogmeldingProducer = mockk<BehandlerDialogmeldingProducer>()
             val mqSenderMock = mockk<MQSenderInterface>()
             val behandlerVarselService = BehandlerVarselService(
@@ -48,6 +50,7 @@ class DialogmeldingServiceSpek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -56,6 +59,7 @@ class DialogmeldingServiceSpek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { behandlerDialogmeldingProducer.sendDialogmelding(any()) }
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
 
             val urlMoter = "$dialogmoteApiV2Basepath/$dialogmoteApiPersonIdentUrlPath"
             val validToken = generateJWT(

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/AvlysDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/AvlysDialogmoteApiV2Spek.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProduc
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
 import no.nav.syfo.brev.behandler.kafka.KafkaBehandlerDialogmeldingDTO
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.oppfolgingstilfelle.toLatestOppfolgingstilfelle
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.database.getMoteStatusEndretNotPublished
@@ -38,6 +39,7 @@ class AvlysDialogmoteApiV2Spek : Spek({
             val database = externalMockEnvironment.database
 
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
             val behandlerDialogmeldingProducer = mockk<BehandlerDialogmeldingProducer>()
             val mqSenderMock = mockk<MQSenderInterface>()
             val behandlerVarselService = BehandlerVarselService(
@@ -49,6 +51,7 @@ class AvlysDialogmoteApiV2Spek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -60,6 +63,8 @@ class AvlysDialogmoteApiV2Spek : Spek({
                 justRun { behandlerDialogmeldingProducer.sendDialogmelding(any()) }
                 clearMocks(mqSenderMock)
                 justRun { mqSenderMock.sendMQMessage(any(), any()) }
+                clearMocks(dineSykmeldteVarselProducer)
+                justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
             }
 
             afterEachTest {

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2AllowVarselMedFysiskBrevSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2AllowVarselMedFysiskBrevSpek.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.oppfolgingstilfelle.toLatestOppfolgingstilfelle
 import no.nav.syfo.dialogmote.PdfService
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
@@ -44,6 +45,9 @@ class FerdigstillDialogmoteApiV2AllowVarselMedFysiskBrevSpek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
@@ -54,6 +58,7 @@ class FerdigstillDialogmoteApiV2AllowVarselMedFysiskBrevSpek : Spek({
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/FerdigstillDialogmoteApiV2Spek.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProduc
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
 import no.nav.syfo.brev.behandler.kafka.KafkaBehandlerDialogmeldingDTO
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.oppfolgingstilfelle.toLatestOppfolgingstilfelle
 import no.nav.syfo.dialogmote.PdfService
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
@@ -47,6 +48,9 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
             justRun { brukernotifikasjonProducer.sendBeskjed(any(), any()) }
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
@@ -64,6 +68,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -74,6 +79,7 @@ class FerdigstillDialogmoteApiV2Spek : Spek({
                 justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
                 justRun { mqSenderMock.sendMQMessage(any(), any()) }
                 justRun { behandlerDialogmeldingProducer.sendDialogmelding(any()) }
+                justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
             }
 
             describe("Ferdigstill Dialogmote") {

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/GetDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/GetDialogmoteApiV2Spek.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.domain.MotedeltakerVarselType
 import no.nav.syfo.testhelper.*
@@ -36,12 +37,16 @@ class GetDialogmoteApiV2Spek : Spek({
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -55,6 +60,7 @@ class GetDialogmoteApiV2Spek : Spek({
                 describe("Happy path") {
                     beforeEachTest {
                         justRun { mqSenderMock.sendMQMessage(any(), any()) }
+                        justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
                         justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
                     }
 

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/GetDialogmoteEnhetApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/GetDialogmoteEnhetApiV2Spek.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.database.createNewDialogmoteWithReferences
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
@@ -40,17 +41,22 @@ class GetDialogmoteEnhetApiV2Spek : Spek({
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
             beforeEachTest {
                 justRun { mqSenderMock.sendMQMessage(any(), any()) }
                 justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
+                justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
                 database.dropData()
             }
 

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/OvertaDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/OvertaDialogmoteApiV2Spek.kt
@@ -8,6 +8,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.api.domain.OvertaDialogmoterDTO
 import no.nav.syfo.dialogmote.database.createNewDialogmoteWithReferences
@@ -37,12 +38,16 @@ class OvertaDialogmoteApiV2Spek : Spek({
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
             justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
 
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
+            justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
+
             val mqSenderMock = mockk<MQSenderInterface>()
             justRun { mqSenderMock.sendMQMessage(any(), any()) }
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -51,6 +56,7 @@ class OvertaDialogmoteApiV2Spek : Spek({
             }
             beforeEachTest {
                 justRun { mqSenderMock.sendMQMessage(any(), any()) }
+                justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
                 justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
             }
 

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2AllowVarselMedFysiskBrevSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2AllowVarselMedFysiskBrevSpek.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.oppfolgingstilfelle.toLatestOppfolgingstilfelle
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.database.getMoteStatusEndretNotPublished
@@ -40,11 +41,13 @@ class PostDialogmoteApiV2AllowVarselMedFysiskBrevSpek : Spek({
             val database = externalMockEnvironment.database
 
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
             val mqSenderMock = mockk<MQSenderInterface>()
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
             )
 
@@ -62,6 +65,8 @@ class PostDialogmoteApiV2AllowVarselMedFysiskBrevSpek : Spek({
                     justRun { brukernotifikasjonProducer.sendOppgave(any(), any()) }
                     clearMocks(mqSenderMock)
                     justRun { mqSenderMock.sendMQMessage(any(), any()) }
+                    clearMocks(dineSykmeldteVarselProducer)
+                    justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
                 }
 
                 afterEachTest {

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2Spek.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProduc
 import no.nav.syfo.brev.behandler.BehandlerVarselService
 import no.nav.syfo.brev.behandler.kafka.BehandlerDialogmeldingProducer
 import no.nav.syfo.brev.behandler.kafka.KafkaBehandlerDialogmeldingDTO
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import no.nav.syfo.client.oppfolgingstilfelle.toLatestOppfolgingstilfelle
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.database.getMoteStatusEndretNotPublished
@@ -49,6 +50,7 @@ class PostDialogmoteApiV2Spek : Spek({
             val database = externalMockEnvironment.database
 
             val brukernotifikasjonProducer = mockk<BrukernotifikasjonProducer>()
+            val dineSykmeldteVarselProducer = mockk<DineSykmeldteVarselProducer>()
             val behandlerDialogmeldingProducer = mockk<BehandlerDialogmeldingProducer>()
             val mqSenderMock = mockk<MQSenderInterface>()
             val altinnMock = mockk<ICorrespondenceAgencyExternalBasic>()
@@ -62,6 +64,7 @@ class PostDialogmoteApiV2Spek : Spek({
                 externalMockEnvironment = externalMockEnvironment,
                 behandlerVarselService = behandlerVarselService,
                 brukernotifikasjonProducer = brukernotifikasjonProducer,
+                dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
                 mqSenderMock = mqSenderMock,
                 altinnMock = altinnMock,
             )
@@ -88,6 +91,8 @@ class PostDialogmoteApiV2Spek : Spek({
                     clearMocks(behandlerDialogmeldingProducer)
                     justRun { behandlerDialogmeldingProducer.sendDialogmelding(any()) }
                     clearMocks(mqSenderMock)
+                    clearMocks(dineSykmeldteVarselProducer)
+                    justRun { dineSykmeldteVarselProducer.sendDineSykmeldteVarsel(any(), any()) }
                     justRun { mqSenderMock.sendMQMessage(any(), any()) }
                     clearMocks(altinnMock)
                     every {

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -8,12 +8,14 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.brev.arbeidstaker.brukernotifikasjon.BrukernotifikasjonProducer
 import no.nav.syfo.brev.behandler.BehandlerVarselService
+import no.nav.syfo.brev.narmesteleder.dinesykmeldte.DineSykmeldteVarselProducer
 import redis.clients.jedis.*
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
     behandlerVarselService: BehandlerVarselService = mockk(),
     brukernotifikasjonProducer: BrukernotifikasjonProducer,
+    dineSykmeldteVarselProducer: DineSykmeldteVarselProducer,
     mqSenderMock: MQSenderInterface,
     altinnMock: ICorrespondenceAgencyExternalBasic = mockk(),
 ) {
@@ -37,5 +39,6 @@ fun Application.testApiModule(
         wellKnownVeilederV2 = externalMockEnvironment.wellKnownVeilederV2,
         cache = cache,
         altinnSoapClient = altinnMock,
+        dineSykmeldteVarselProducer = dineSykmeldteVarselProducer
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -39,6 +39,6 @@ fun Application.testApiModule(
         wellKnownVeilederV2 = externalMockEnvironment.wellKnownVeilederV2,
         cache = cache,
         altinnSoapClient = altinnMock,
-        dineSykmeldteVarselProducer = dineSykmeldteVarselProducer
+        dineSykmeldteVarselProducer = dineSykmeldteVarselProducer,
     )
 }


### PR DESCRIPTION
Nye dine sykmeldte går live på mandag, og vi har ikke klart å få på plass ordentlig løsning for varselutsending enda.

Tanken er at esyfovarsel håndterer utsending, og så kan både MQ-utsending og dine sykmeldte-varsler fases ut fra isdialogmøte.

Men inntil det er på plass må isdialogmote stå for utsending til nye dine sykmeldte.