### PR TITLE
Increase resources to handle peak demand

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -9,8 +9,8 @@ spec:
   image: {{ image }}
   port: 8080
   replicas:
-    min: 2
-    max: 4
+    min: 3
+    max: 6
     cpuThresholdPercentage: 70
   startup:
     path: /internal/is_ready
@@ -34,10 +34,10 @@ spec:
   resources:
     limits:
       cpu: 200m
-      memory: 512Mi
+      memory: 768Mi
     requests:
       cpu: 100m
-      memory: 384Mi
+      memory: 512Mi
   ingresses:
     - "https://isdialogmote.intern.nav.no"
     - "https://isdialogmote.nav.no"


### PR DESCRIPTION
Increase pod memory and minimum number of pods to 3 to handle peak demand.