### PR TITLE
Use retry to handle ClosedReceiveChannelException

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.jackson.*
 import no.nav.syfo.util.configure
@@ -12,6 +13,20 @@ import java.net.ProxySelector
 fun httpClientDefault() = HttpClient(CIO) {
     install(ContentNegotiation) {
         jackson { configure() }
+    }
+    expectSuccess = true
+}
+
+fun httpClientWithRetry(
+    numberOfRetries: Int = 2,
+    delayMilliseconds: Long = 500L,
+) = HttpClient(CIO) {
+    install(ContentNegotiation) {
+        jackson { configure() }
+    }
+    install(HttpRequestRetry) {
+        retryOnException(numberOfRetries)
+        constantDelay(delayMilliseconds)
     }
     expectSuccess = true
 }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -6,7 +6,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.syfo.client.azuread.AzureAdV2Client
 import no.nav.syfo.client.azuread.AzureAdV2Token
-import no.nav.syfo.client.httpClientDefault
+import no.nav.syfo.client.httpClientWithRetry
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.metric.COUNT_CALL_PDL_FAIL
 import no.nav.syfo.metric.COUNT_CALL_PDL_SUCCESS
@@ -18,7 +18,7 @@ class PdlClient(
     private val pdlClientId: String,
     private val pdlUrl: String,
 ) {
-    private val httpClient = httpClientDefault()
+    private val httpClient = httpClientWithRetry()
 
     suspend fun navn(
         personIdent: PersonIdentNumber,


### PR DESCRIPTION
Vi får ganske hyppig
java.lang.RuntimeException: Caught ClosedReceiveChannelException in hasAdressebeskyttelse

Gjør et forsøk på å ta i bruk retry-logikken i ktor 2.0 for å forbedre det.