### PR TITLE
Use retry to handle ClosedReceiveChannelException generally

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -14,19 +14,11 @@ fun httpClientDefault() = HttpClient(CIO) {
     install(ContentNegotiation) {
         jackson { configure() }
     }
-    expectSuccess = true
-}
-
-fun httpClientWithRetry(
-    numberOfRetries: Int = 2,
-    delayMilliseconds: Long = 500L,
-) = HttpClient(CIO) {
-    install(ContentNegotiation) {
-        jackson { configure() }
-    }
     install(HttpRequestRetry) {
-        retryOnException(numberOfRetries)
-        constantDelay(delayMilliseconds)
+        retryOnExceptionIf(2) { _, cause ->
+            cause !is ClientRequestException
+        }
+        constantDelay(500L)
     }
     expectSuccess = true
 }
@@ -34,6 +26,12 @@ fun httpClientWithRetry(
 val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     install(ContentNegotiation) {
         jackson { configure() }
+    }
+    install(HttpRequestRetry) {
+        retryOnExceptionIf(2) { _, cause ->
+            cause !is ClientRequestException
+        }
+        constantDelay(500L)
     }
     expectSuccess = true
     engine {

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -6,7 +6,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.syfo.client.azuread.AzureAdV2Client
 import no.nav.syfo.client.azuread.AzureAdV2Token
-import no.nav.syfo.client.httpClientWithRetry
+import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.metric.COUNT_CALL_PDL_FAIL
 import no.nav.syfo.metric.COUNT_CALL_PDL_SUCCESS
@@ -18,7 +18,7 @@ class PdlClient(
     private val pdlClientId: String,
     private val pdlUrl: String,
 ) {
-    private val httpClient = httpClientWithRetry()
+    private val httpClient = httpClientDefault()
 
     suspend fun navn(
         personIdent: PersonIdentNumber,


### PR DESCRIPTION
Ser ut som denne retry-funksjonaliteten fungerer bra (og i hvert fall ikke gjør noen skade). Så legger det inn sånn at det har effekt for alle klientene i app'en.