### PR TITLE
Reduce interval of PublishDialogmoteStatusEndringCronjob

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringCronjob.kt
@@ -9,7 +9,7 @@ class PublishDialogmoteStatusEndringCronjob(
 ) : DialogmoteCronjob {
 
     override val initialDelayMinutes: Long = 2
-    override val intervalDelayMinutes: Long = 60
+    override val intervalDelayMinutes: Long = 1
 
     override suspend fun run() {
         dialogmoteStatusEndringPublishJob()

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteStatusEndretQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteStatusEndretQuery.kt
@@ -59,16 +59,17 @@ fun Connection.createMoteStatusEndring(
     return Pair(moteStatusEndringIdList.first(), moteStatusEndringUuid)
 }
 
-const val queryMoteStatusEndretWihtoutPublished =
+const val queryMoteStatusEndretNotPublished =
     """
         SELECT *
         FROM MOTE_STATUS_ENDRET
         WHERE published_at IS NULL
+        ORDER BY created_at ASC LIMIT 100
     """
 
 fun DatabaseInterface.getMoteStatusEndretNotPublished(): List<PMoteStatusEndret> {
     return this.connection.use { connection ->
-        connection.prepareStatement(queryMoteStatusEndretWihtoutPublished).use {
+        connection.prepareStatement(queryMoteStatusEndretNotPublished).use {
             it.executeQuery().toList { toPMoteStatusEndret() }
         }
     }


### PR DESCRIPTION
Reduce interval from 60 minutes to 1 minute to provide almost-instant update for consumers of Kafka topic