### PR TITLE
Handle NoContent when getting behandlende enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/behandlendeenhet/BehandlendeEnhetClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/behandlendeenhet/BehandlendeEnhetClient.kt
@@ -43,7 +43,11 @@ class BehandlendeEnhetClient(
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_BEHANDLENDEENHET_SUCCESS.increment()
-            response.body()
+            when (response.status) {
+                HttpStatusCode.OK -> response.body()
+                HttpStatusCode.NoContent -> null
+                else -> handleUnexpectedResponseException(response, callId)
+            }
         } catch (e: ClientRequestException) {
             handleUnexpectedResponseException(e.response, callId)
         } catch (e: ServerResponseException) {

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -121,7 +121,7 @@ class DialogmoteService(
             callId = callId,
             personIdentNumber = personIdentNumber,
             token = token,
-        ) ?: throw RuntimeException("Failed to request BehandlendeEnhet of Person")
+        ) ?: throw RuntimeException("Failed to request (or missing) BehandlendeEnhet of Person")
 
         val newDialogmote = newDialogmoteDTO.toNewDialogmote(
             requestByNAVIdent = getNAVIdentFromToken(token),

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/PostDialogmoteApiV2Spek.kt
@@ -25,6 +25,7 @@ import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_BEHANDLENDE_ENHET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER
 import no.nav.syfo.testhelper.UserConstants.ENHET_NR
@@ -447,6 +448,20 @@ class PostDialogmoteApiV2Spek : Spek({
 
                     it("should return InternalServerError if requesting to create Dialogmote for PersonIdent with inactive Oppfolgingstilfelle") {
                         val newDialogmoteDTO = generateNewDialogmoteDTO(ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE)
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader(Authorization, bearerHeader(validToken))
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.InternalServerError
+                            verify(exactly = 0) { mqSenderMock.sendMQMessage(MotedeltakerVarselType.INNKALT, any()) }
+                            clearMocks(mqSenderMock)
+                        }
+                    }
+                    it("should return InternalServerError if requesting to create Dialogmote for PersonIdent no behandlende enhet") {
+                        val newDialogmoteDTO = generateNewDialogmoteDTO(ARBEIDSTAKER_NO_BEHANDLENDE_ENHET)
                         with(
                             handleRequest(HttpMethod.Post, url) {
                                 addHeader(Authorization, bearerHeader(validToken))

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -12,6 +12,7 @@ object UserConstants {
     val ARBEIDSTAKER_IKKE_VARSEL = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "7"))
     val ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "8"))
     val ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "9"))
+    val ARBEIDSTAKER_NO_BEHANDLENDE_ENHET = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("3", "1"))
 
     const val VEILEDER_IDENT = "Z999999"
     const val VEILEDER_IDENT_2 = "Z999998"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/SyfobehandlendeenhetMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/SyfobehandlendeenhetMock.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ANNEN_FNR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_IKKE_VARSEL
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_BEHANDLENDE_ENHET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_JOURNALFORING
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER
 import no.nav.syfo.testhelper.UserConstants.ENHET_NR
@@ -43,15 +44,18 @@ class SyfobehandlendeenhetMock {
             installContentNegotiation()
             routing {
                 get(PERSON_V2_ENHET_PATH) {
+                    val personIdent = getPersonIdentHeader()
                     if (
-                        getPersonIdentHeader() == ARBEIDSTAKER_FNR.value ||
-                        getPersonIdentHeader() == ARBEIDSTAKER_ANNEN_FNR.value ||
-                        getPersonIdentHeader() == ARBEIDSTAKER_NO_JOURNALFORING.value ||
-                        getPersonIdentHeader() == ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE.value ||
-                        getPersonIdentHeader() == ARBEIDSTAKER_IKKE_VARSEL.value ||
-                        getPersonIdentHeader() == ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER.value
+                        personIdent == ARBEIDSTAKER_FNR.value ||
+                        personIdent == ARBEIDSTAKER_ANNEN_FNR.value ||
+                        personIdent == ARBEIDSTAKER_NO_JOURNALFORING.value ||
+                        personIdent == ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE.value ||
+                        personIdent == ARBEIDSTAKER_IKKE_VARSEL.value ||
+                        personIdent == ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER.value
                     ) {
                         call.respond(behandlendeEnhetDTO)
+                    } else if (personIdent == ARBEIDSTAKER_NO_BEHANDLENDE_ENHET.value) {
+                        call.respond(HttpStatusCode.NoContent, "")
                     } else {
                         call.respond(HttpStatusCode.InternalServerError, "")
                     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ANNEN_FNR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_IKKE_VARSEL
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_BEHANDLENDE_ENHET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_JOURNALFORING
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER
 import no.nav.syfo.testhelper.UserConstants.ENHET_NR
@@ -59,6 +60,7 @@ class VeilederTilgangskontrollMock {
                             ARBEIDSTAKER_IKKE_VARSEL.value,
                             ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER.value,
                             ARBEIDSTAKER_INACTIVE_OPPFOLGINGSTILFELLE.value,
+                            ARBEIDSTAKER_NO_BEHANDLENDE_ENHET.value,
                         )
                     )
                 }


### PR DESCRIPTION
For brukerne vil ikke dette oppføre seg noe forskjellig, men jeg synes det er riktigere å håndtere NoContent i BehandlendeEnhetClient og tilpasse feilhåndteringen for manglende behandlende enhet.