### PR TITLE
Add new consumer for #dv-team-sykefravær

### DIFF
--- a/.nais/kafka/statusendring.yaml
+++ b/.nais/kafka/statusendring.yaml
@@ -38,3 +38,6 @@ spec:
     - team: teamsykefravr
       application: syfooversiktsrv
       access: read
+    - team: disykefravar
+      application: dvh-syfo-isdialogmote-konsument
+      access: read


### PR DESCRIPTION
This consumer is meant to replace dvh-syfodm2-konsument in the fall of 2022.

Jira: https://jira.adeo.no/browse/STO-2524
