### PR TITLE
Add timestamp for motesvar published on kafka

### DIFF
--- a/src/main/resources/db/migration/V8_3__add_motesvar_kafka.sql
+++ b/src/main/resources/db/migration/V8_3__add_motesvar_kafka.sql
@@ -1,0 +1,8 @@
+ALTER TABLE motedeltaker_arbeidstaker_varsel
+    ADD COLUMN svar_published_to_kafka_at TIMESTAMPTZ DEFAULT NULL;
+
+ALTER TABLE motedeltaker_arbeidsgiver_varsel
+    ADD COLUMN svar_published_to_kafka_at TIMESTAMPTZ DEFAULT NULL;
+
+ALTER TABLE motedeltaker_behandler_varsel_svar
+    ADD COLUMN svar_published_to_kafka_at TIMESTAMPTZ DEFAULT NULL;


### PR DESCRIPTION
Add to "varsel" tables for AG/AT, and "varsel_svar" table for behandler.