### PR TITLE
Enable KODE6 access in prod

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -149,4 +149,4 @@ spec:
     - name: ALTINN_SENDING_ENABLED
       value: "true"
     - name: KODE6_ENABLED
-      value: "false"
+      value: "true"


### PR DESCRIPTION
Maybe remove entire toggle after verification by a veileder in prod?