### PR TITLE
Set the time veileder made the statusendring as endringstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringService.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/statusendring/PublishDialogmoteStatusEndringService.kt
@@ -52,7 +52,7 @@ fun createKDialogmoteStatusEndring(
     kDialogmoteStatusEndring.setDialogmoteUuid(pDialogmote.uuid.toString())
     kDialogmoteStatusEndring.setDialogmoteTidspunkt(dialogmoteTidStedList.latest()!!.tid.toInstantOslo())
     kDialogmoteStatusEndring.setStatusEndringType(dialogmoteStatusEndret.status.name)
-    kDialogmoteStatusEndring.setStatusEndringTidspunkt(LocalDateTime.now().toInstantOslo())
+    kDialogmoteStatusEndring.setStatusEndringTidspunkt(dialogmoteStatusEndret.createdAt.toInstantOslo())
     kDialogmoteStatusEndring.setPersonIdent(personIdent.value)
     kDialogmoteStatusEndring.setVirksomhetsnummer(virksomhetsnummer.value)
     kDialogmoteStatusEndring.setEnhetNr(pDialogmote.tildeltEnhet)


### PR DESCRIPTION
If we use "now" it will always be shifted by the amount of time it took the cronjob to fetch the statusendring from the database.

Co-authored-by: June Henriksen <june.henriksen2@nav.no>