### PR TITLE
Lukke moter adhoc

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -147,9 +147,9 @@ spec:
     - name: DOKDIST_FORDELING_CLIENT_ID
       value: "prod-fss.teamdokumenthandtering.saf"
     - name: OUTDATED_DIALOGMOTE_CUTOFF
-      value: "2022-07-01"
+      value: "2000-07-01"
     - name: OUTDATED_DIALOGMOTE_CRONJOB_ENABLED
-      value: "false"
+      value: "true"
     - name: ALTINN_SENDING_ENABLED
       value: "true"
     - name: KODE6_ENABLED

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmoteOutdated/DialogmoteOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmoteOutdated/DialogmoteOutdatedCronjob.kt
@@ -6,10 +6,12 @@ import no.nav.syfo.cronjob.*
 import no.nav.syfo.dialogmote.DialogmoterelasjonService
 import no.nav.syfo.dialogmote.DialogmotestatusService
 import no.nav.syfo.dialogmote.database.findOutdatedMoter
+import no.nav.syfo.dialogmote.database.getDialogmote
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.dialogmote.domain.latest
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import java.util.UUID
 
 class DialogmoteOutdatedCronjob(
     val dialogmotestatusService: DialogmotestatusService,
@@ -18,7 +20,7 @@ class DialogmoteOutdatedCronjob(
     val outdatedDialogmoterCutoff: LocalDate,
 ) : DialogmoteCronjob {
 
-    override val initialDelayMinutes: Long = 2
+    override val initialDelayMinutes: Long = 4
     override val intervalDelayMinutes: Long = 240
 
     override suspend fun run() {
@@ -40,9 +42,15 @@ class DialogmoteOutdatedCronjob(
         outdatedResult: DialogmoteCronjobResult,
     ) {
         val cutoff = outdatedDialogmoterCutoff.atStartOfDay()
-        val moteListe = database.findOutdatedMoter(cutoff).map { dialogmoterelasjonService.extendDialogmoteRelations(it) }
-        log.info("Cronjob for outdated moter found count: ${moteListe.size}")
-        for (mote in moteListe) {
+        val moteListe = database.findOutdatedMoter(cutoff)
+        // moter som skal lukkes adhoc (basert på hardkodet liste med uuid'er)
+        uuids.forEach { uuid -> moteListe.addAll(database.getDialogmote(UUID.fromString(uuid))) }
+        moteListe.retainAll { pDialogmote ->
+            pDialogmote.status == DialogmoteStatus.INNKALT.name || pDialogmote.status == DialogmoteStatus.NYTT_TID_STED.name
+        }
+        val dialogmoteList = moteListe.map { dialogmoterelasjonService.extendDialogmoteRelations(it) }
+        log.info("Cronjob for outdated moter found count: ${dialogmoteList.size}")
+        for (mote in dialogmoteList) {
             try {
                 val motetidspunkt = mote.tidStedList.latest()?.tid
                 log.info("Found outdated mote: ${mote.uuid} with status ${mote.status} and moteTidspunkt: $motetidspunkt")
@@ -64,6 +72,7 @@ class DialogmoteOutdatedCronjob(
     }
 
     companion object {
+        private val uuids = listOf("1e34e92c-bcc7-402c-8ab4-5bd2d040df9a")
         private val log = LoggerFactory.getLogger(DialogmoteOutdatedCronjob::class.java)
     }
 }


### PR DESCRIPTION
Det har dukket opp et behov for å få lukket et møte uten at det genereres tilhørende varsler, så da bruker vi mekanismen i den nye cronjob'en til dette.