### PR TITLE
Not throw error when activeident is null

### DIFF
--- a/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/kafka/KafkaIdenthendelseDTO.kt
@@ -9,13 +9,12 @@ data class KafkaIdenthendelseDTO(
 ) {
     val folkeregisterIdenter = identifikatorer.filter { it.type == IdentType.FOLKEREGISTERIDENT }
 
-    val activePersonident: PersonIdent = folkeregisterIdenter
+    fun getActivePersonident(): PersonIdent? = folkeregisterIdenter
         .find { it.gjeldende }
         ?.idnummer
         ?.let { PersonIdent(it) }
-        ?: throw IllegalStateException("Mangler gyldig ident fra PDL")
 
-    val inactivePersonidenter: List<PersonIdent> = folkeregisterIdenter
+    fun getInactivePersonidenter(): List<PersonIdent> = folkeregisterIdenter
         .filter { !it.gjeldende }
         .map { PersonIdent(it.idnummer) }
 }

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -61,8 +61,8 @@ object IdenthendelseServiceSpek : Spek({
             describe("Happy path") {
                 it("Skal oppdatere database når arbeidstaker har fått ny ident") {
                     val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTOGenerator(hasOldPersonident = true)
-                    val newIdent = kafkaIdenthendelseDTO.activePersonident
-                    val oldIdent = kafkaIdenthendelseDTO.inactivePersonidenter.first()
+                    val newIdent = kafkaIdenthendelseDTO.getActivePersonident()!!
+                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
 
                     // Populate database with new dialogmote using old ident for arbeidstaker
                     val newDialogmote = generateNewDialogmote(personIdent = oldIdent)
@@ -96,7 +96,7 @@ object IdenthendelseServiceSpek : Spek({
 
                 it("Skal ikke oppdatere database når arbeidstaker ikke finnes i databasen") {
                     val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTOGenerator(hasOldPersonident = true)
-                    val newIdent = kafkaIdenthendelseDTO.activePersonident
+                    val newIdent = kafkaIdenthendelseDTO.getActivePersonident()!!
                     val oldIdent = PersonIdent("12333378910")
 
                     // Check that arbeidstaker with old/current personident do not exist in db before update
@@ -118,7 +118,7 @@ object IdenthendelseServiceSpek : Spek({
 
                 it("Skal ikke oppdatere database når arbeidstaker ikke har gamle identer") {
                     val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTOGenerator(hasOldPersonident = false)
-                    val newIdent = kafkaIdenthendelseDTO.activePersonident
+                    val newIdent = kafkaIdenthendelseDTO.getActivePersonident()!!
 
                     // Check that arbeidstaker with new personident do not exist in db before update
                     val newMotedeltakerArbeidstaker = database.getMotedeltakerArbeidstakerByIdent(newIdent)
@@ -140,7 +140,7 @@ object IdenthendelseServiceSpek : Spek({
                         personident = UserConstants.ARBEIDSTAKER_TREDJE_FNR,
                         hasOldPersonident = true,
                     )
-                    val oldIdent = kafkaIdenthendelseDTO.inactivePersonidenter.first()
+                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
 
                     // Populate database with new dialogmote using old ident for arbeidstaker
                     val newDialogmote = generateNewDialogmote(personIdent = oldIdent)


### PR DESCRIPTION
Dersom personene som kommer inn ikke har folkeidentifikator, så vil activeIdent bli null og kaste en feil. Siden verdiene activePersonident og inactivePersonident blir kalkulert for hver record, så slår feilen ut allerede før vi vet at personen har flere identer, som ikke er nødvendig. Ved å heller gjøre en sjekk på null-verdi enn å kaste feil, så vil vi forhåpentligvis unngå at den havner i en retry-loop. I tillegg så gjør man kalkuleringene på getActivePersonident() som en funksjon i stedet for variabel, slik at kalkulasjonen gjøres når den faktisk blir kalt. Da kalkulerer vi bare for de få tilfellene vi må oppdatere, ikke alle 10 millioner (tror jeg).