### PR TITLE
Only publish valid behandlersvar to kafka

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/BehandlersvarPublishedToKafkaAtQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/BehandlersvarPublishedToKafkaAtQueries.kt
@@ -19,6 +19,7 @@ const val queryGetUnpublishedBehandlersvar =
         INNER JOIN mote m ON mb.mote_id = m.id
         INNER JOIN motedeltaker_arbeidstaker ma ON m.id = ma.mote_id
         WHERE s.svar_published_to_kafka_at IS NULL
+        AND s.valid IS TRUE
         LIMIT 100;
     """
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselSvarQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselSvarQuery.kt
@@ -18,8 +18,9 @@ const val queryCreateMotedeltakerBehandlerVarselSvar =
             motedeltaker_behandler_varsel_id,
             svar_type,                       
             svar_tekst,
-            msg_id
-        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?) RETURNING id
+            msg_id,
+            valid
+        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?) RETURNING id
     """
 
 fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
@@ -27,6 +28,7 @@ fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
     type: DialogmoteSvarType,
     tekst: String?,
     msgId: String,
+    valid: Boolean = true,
 ): Pair<Int, UUID> {
     val now = Timestamp.from(Instant.now())
     val svarUUID = UUID.randomUUID()
@@ -39,6 +41,7 @@ fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
             it.setString(4, type.name)
             it.setString(5, tekst.orEmpty())
             it.setString(6, msgId)
+            it.setBoolean(7, valid)
             it.executeQuery().toList { getInt("id") }
         }
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotesvar/PublishDialogmotesvarServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotesvar/PublishDialogmotesvarServiceSpek.kt
@@ -95,6 +95,31 @@ class PublishDialogmotesvarServiceSpek : Spek({
                 dialogmotesvarList.size shouldBeEqualTo 1
             }
 
+            it("Behandlers answer is not valid and will not be published") {
+                val identifiers = database.connection.createNewDialogmoteWithReferences(
+                    newDialogmote = generateNewDialogmoteWithBehandler(
+                        UserConstants.ARBEIDSTAKER_FNR,
+                        DialogmoteStatus.INNKALT,
+                    )
+                )
+                val varselId = database.connection.createBehandlerVarsel(
+                    UUID.randomUUID(),
+                    MotedeltakerVarselType.INNKALT,
+                    identifiers.motedeltakerBehandlerIdPair?.first,
+                )
+                val kommerIkkeSvarUuid = UUID.randomUUID()
+                database.connection.createBehandlerVarselSvar(
+                    svarUuid = kommerIkkeSvarUuid,
+                    varselId = varselId,
+                    svarType = DialogmoteSvarType.KOMMER_IKKE,
+                    valid = false,
+                )
+
+                val dialogmotesvarList = publishDialogmotesvarService.getUnpublishedDialogmotesvar()
+
+                dialogmotesvarList.size shouldBeEqualTo 0
+            }
+
             it("Get unpublished møtesvar from both arbeidsgiver and arbeidstaker") {
                 val identifiers = database.connection.createNewDialogmoteWithReferences(
                     newDialogmote = generateNewDialogmoteWithBehandler(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -236,19 +236,21 @@ fun Connection.createBehandlerVarsel(
 
 const val createBehandlerVarselSvarQuery =
     """
-    INSERT INTO MOTEDELTAKER_BEHANDLER_VARSEL_SVAR(uuid, created_at, motedeltaker_behandler_varsel_id, svar_type, svar_tekst, msg_id)
-    VALUES (?, now(), ?, ?, '', '')
+    INSERT INTO MOTEDELTAKER_BEHANDLER_VARSEL_SVAR(uuid, created_at, motedeltaker_behandler_varsel_id, svar_type, svar_tekst, msg_id, valid)
+    VALUES (?, now(), ?, ?, '', '', ?)
 """
 
 fun Connection.createBehandlerVarselSvar(
     svarUuid: UUID,
     varselId: Int,
     svarType: DialogmoteSvarType,
+    valid: Boolean = true,
 ) {
     prepareStatement(createBehandlerVarselSvarQuery).use {
         it.setString(1, svarUuid.toString())
         it.setInt(2, varselId)
         it.setString(3, svarType.name)
+        it.setBoolean(4, valid)
         it.execute()
     }
     commit()


### PR DESCRIPTION
This is to ensure ispersonoppgave don't open a new oppgave after the meeting is ferdigstilt/avlyst.

Co-authored-by: June Henriksen <june.henriksen2@nav.no>