### PR TITLE
Do not invalidate a late behandler svar

### DIFF
--- a/src/main/kotlin/no/nav/syfo/brev/behandler/BehandlerVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/brev/behandler/BehandlerVarselService.kt
@@ -8,7 +8,6 @@ import no.nav.syfo.dialogmelding.COUNT_CREATE_INNKALLING_DIALOGMOTE_SVAR_BEHANDL
 import no.nav.syfo.dialogmelding.domain.DialogmeldingSvar
 import no.nav.syfo.dialogmelding.domain.getDialogmoteSvarType
 import no.nav.syfo.dialogmelding.domain.getVarselType
-import no.nav.syfo.dialogmelding.domain.happenedBefore
 import no.nav.syfo.dialogmote.database.*
 import no.nav.syfo.dialogmote.database.domain.PMotedeltakerBehandlerVarsel
 import no.nav.syfo.dialogmote.domain.*
@@ -78,16 +77,11 @@ class BehandlerVarselService(
                     log.error("Could not find mote for behandlerVarsel ${pMotedeltakerBehandlerVarsel.uuid} conversationRef $conversationRef, parentRef $parentRef and msgId $msgId - Did not create svar")
                     return false
                 }
-                val moteStatus = DialogmoteStatus.valueOf(currentMote.status)
-                val moteUpdatedAt = currentMote.updatedAt
-                val isBehandlerSvarOnTime = moteStatus.unfinished() ||
-                    dialogmeldingSvar happenedBefore moteUpdatedAt
                 database.createMotedeltakerBehandlerVarselSvar(
                     motedeltakerBehandlerVarselId = pMotedeltakerBehandlerVarsel.id,
                     type = svarType,
                     tekst = svarTekst,
                     msgId = msgId,
-                    valid = isBehandlerSvarOnTime,
                 )
                 log.info("Created svar $svarType på varsel $varseltype with uuid ${pMotedeltakerBehandlerVarsel.uuid}")
                 COUNT_CREATE_INNKALLING_DIALOGMOTE_SVAR_BEHANDLER_SUCCESS.increment()

--- a/src/main/kotlin/no/nav/syfo/dialogmelding/domain/DialogmeldingSvar.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/domain/DialogmeldingSvar.kt
@@ -45,5 +45,3 @@ fun ForesporselType.getVarselType(): MotedeltakerVarselType {
         ForesporselType.ENDRING -> MotedeltakerVarselType.NYTT_TID_STED
     }
 }
-
-infix fun DialogmeldingSvar.happenedBefore(tidspunkt: LocalDateTime) = opprettetTidspunkt.isBefore(tidspunkt)

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/BehandlersvarPublishedToKafkaAtQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/BehandlersvarPublishedToKafkaAtQueries.kt
@@ -19,7 +19,6 @@ const val queryGetUnpublishedBehandlersvar =
         INNER JOIN mote m ON mb.mote_id = m.id
         INNER JOIN motedeltaker_arbeidstaker ma ON m.id = ma.mote_id
         WHERE s.svar_published_to_kafka_at IS NULL
-        AND s.valid IS TRUE
         LIMIT 100;
     """
 

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselSvarQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MotedeltakerBehandlerVarselSvarQuery.kt
@@ -18,9 +18,8 @@ const val queryCreateMotedeltakerBehandlerVarselSvar =
             motedeltaker_behandler_varsel_id,
             svar_type,                       
             svar_tekst,
-            msg_id,
-            valid
-        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+            msg_id
+        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?) RETURNING id
     """
 
 fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
@@ -28,7 +27,6 @@ fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
     type: DialogmoteSvarType,
     tekst: String?,
     msgId: String,
-    valid: Boolean,
 ): Pair<Int, UUID> {
     val now = Timestamp.from(Instant.now())
     val svarUUID = UUID.randomUUID()
@@ -41,7 +39,6 @@ fun DatabaseInterface.createMotedeltakerBehandlerVarselSvar(
             it.setString(4, type.name)
             it.setString(5, tekst.orEmpty())
             it.setString(6, msgId)
-            it.setBoolean(7, valid)
             it.executeQuery().toList { getInt("id") }
         }
 

--- a/src/test/kotlin/no/nav/syfo/brev/behandler/BehandlerVarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/brev/behandler/BehandlerVarselServiceSpek.kt
@@ -75,7 +75,6 @@ class BehandlerVarselServiceSpek : Spek({
                         any(),
                         any(),
                         any(),
-                        any(),
                         any()
                     )
                 }
@@ -95,7 +94,7 @@ class BehandlerVarselServiceSpek : Spek({
                     )
                 } returns Pair(1, pMotedeltakerBehandlerVarsel)
                 every { database.getMote(any()) } returns pDialogmote
-                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
+                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
 
                 val isSvarSaved = behandlerVarselService.finnBehandlerVarselOgOpprettSvar(
                     dialogmeldingSvar = dialogmeldingSvar,
@@ -116,8 +115,7 @@ class BehandlerVarselServiceSpek : Spek({
                         motedeltakerBehandlerVarselId = 1,
                         type = DialogmoteSvarType.KOMMER_IKKE,
                         tekst = "tekst",
-                        msgId = "321",
-                        valid = true
+                        msgId = "321"
                     )
                 }
             }
@@ -142,7 +140,7 @@ class BehandlerVarselServiceSpek : Spek({
                     )
                 } returns Pair(1, pMotedeltakerBehandlerVarsel)
                 every { database.getMote(any()) } returns pDialogmote
-                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
+                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
 
                 val isSvarSaved = behandlerVarselService.finnBehandlerVarselOgOpprettSvar(
                     dialogmeldingSvar = dialogmeldingSvar,
@@ -163,8 +161,7 @@ class BehandlerVarselServiceSpek : Spek({
                         motedeltakerBehandlerVarselId = 1,
                         type = DialogmoteSvarType.KOMMER_IKKE,
                         tekst = "tekst",
-                        msgId = "321",
-                        valid = true,
+                        msgId = "321"
                     )
                 }
             }
@@ -189,7 +186,7 @@ class BehandlerVarselServiceSpek : Spek({
                     )
                 } returns Pair(1, pMotedeltakerBehandlerVarsel)
                 every { database.getMote(any()) } returns pDialogmote
-                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
+                every { database.createMotedeltakerBehandlerVarselSvar(any(), any(), any(), any()) } returns Pair(1, UUID.randomUUID())
 
                 val isSvarSaved = behandlerVarselService.finnBehandlerVarselOgOpprettSvar(
                     dialogmeldingSvar = dialogmeldingSvar,
@@ -210,8 +207,7 @@ class BehandlerVarselServiceSpek : Spek({
                         motedeltakerBehandlerVarselId = 1,
                         type = DialogmoteSvarType.KOMMER_IKKE,
                         tekst = "tekst",
-                        msgId = "321",
-                        valid = false,
+                        msgId = "321"
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotesvar/PublishDialogmotesvarServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotesvar/PublishDialogmotesvarServiceSpek.kt
@@ -95,11 +95,11 @@ class PublishDialogmotesvarServiceSpek : Spek({
                 dialogmotesvarList.size shouldBeEqualTo 1
             }
 
-            it("Behandlers answer is not valid and will not be published") {
+            it("Behandlers answer is too late, but the answer is still published") {
                 val identifiers = database.connection.createNewDialogmoteWithReferences(
                     newDialogmote = generateNewDialogmoteWithBehandler(
                         UserConstants.ARBEIDSTAKER_FNR,
-                        DialogmoteStatus.INNKALT,
+                        DialogmoteStatus.AVLYST,
                     )
                 )
                 val varselId = database.connection.createBehandlerVarsel(
@@ -112,12 +112,11 @@ class PublishDialogmotesvarServiceSpek : Spek({
                     svarUuid = kommerIkkeSvarUuid,
                     varselId = varselId,
                     svarType = DialogmoteSvarType.KOMMER_IKKE,
-                    valid = false,
                 )
 
                 val dialogmotesvarList = publishDialogmotesvarService.getUnpublishedDialogmotesvar()
 
-                dialogmotesvarList.size shouldBeEqualTo 0
+                dialogmotesvarList.size shouldBeEqualTo 1
             }
 
             it("Get unpublished møtesvar from both arbeidsgiver and arbeidstaker") {

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -236,21 +236,19 @@ fun Connection.createBehandlerVarsel(
 
 const val createBehandlerVarselSvarQuery =
     """
-    INSERT INTO MOTEDELTAKER_BEHANDLER_VARSEL_SVAR(uuid, created_at, motedeltaker_behandler_varsel_id, svar_type, svar_tekst, msg_id, valid)
-    VALUES (?, now(), ?, ?, '', '', ?)
+    INSERT INTO MOTEDELTAKER_BEHANDLER_VARSEL_SVAR(uuid, created_at, motedeltaker_behandler_varsel_id, svar_type, svar_tekst, msg_id)
+    VALUES (?, now(), ?, ?, '', '')
 """
 
 fun Connection.createBehandlerVarselSvar(
     svarUuid: UUID,
     varselId: Int,
     svarType: DialogmoteSvarType,
-    valid: Boolean = true,
 ) {
     prepareStatement(createBehandlerVarselSvarQuery).use {
         it.setString(1, svarUuid.toString())
         it.setInt(2, varselId)
         it.setString(3, svarType.name)
-        it.setBoolean(4, valid)
         it.execute()
     }
     commit()


### PR DESCRIPTION
Remove concept that a behandler svar can be invalid and put all behandler svar on kafka. This means that a late behandler svar, i.e we recieve it after a meeting is closed, must be handled by the consumer (if it deems it necessary).

The only consumer currently is ispersonoppgave, which means this commit must be merged after it's handled there.