### PR TITLE
Remove vulnerability in velocity-dependency

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -138,7 +138,7 @@ spec:
     - name: OUTDATED_DIALOGMOTE_CRONJOB_ENABLED
       value: "true"
     - name: ALTINN_SENDING_ENABLED
-      value: "false"
+      value: "true"
     - name: KODE6_ENABLED
       value: "true"
     - name: PUBLISH_DIALOGMOTESVAR_ENABLED

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 object Versions {
     const val altinnCorrespondenceAgencyExternalVersion = "1.2020.01.20-15.44-063ae9f84815"
-    const val cxfVersion = "3.5.5"
+    const val cxfVersion = "4.0.2"
     const val confluent = "7.4.0"
     const val flyway = "9.20.0"
     const val hikari = "5.0.1"
@@ -170,6 +170,32 @@ dependencies {
     implementation("org.apache.cxf:cxf-rt-features-logging:${Versions.cxfVersion}")
     implementation("org.apache.cxf:cxf-rt-transports-http:${Versions.cxfVersion}")
     implementation("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}")
+    constraints {
+        implementation("org.opensaml:opensaml-saml-impl") {
+            because("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}-> https://github.com/advisories/GHSA-59j4-wjwp-mw9m")
+            version {
+                strictly("4.0.1")
+            }
+        }
+        implementation("org.opensaml:opensaml-xacml-saml-impl") {
+            because("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}-> https://github.com/advisories/GHSA-59j4-wjwp-mw9m")
+            version {
+                strictly("4.0.1")
+            }
+        }
+        implementation("org.opensaml:opensaml-xacml-impl") {
+            because("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}-> https://github.com/advisories/GHSA-59j4-wjwp-mw9m")
+            version {
+                strictly("4.0.1")
+            }
+        }
+        implementation("org.apache.velocity:velocity-engine-core") {
+            because("org.apache.cxf:cxf-rt-ws-security:${Versions.cxfVersion}-> https://github.com/advisories/GHSA-59j4-wjwp-mw9m")
+            version {
+                strictly("2.3")
+            }
+        }
+    }
     implementation("javax.xml.ws:jaxws-api:${Versions.jaxsWsApiVersion}")
     implementation("com.sun.xml.ws:jaxws-tools:${Versions.jaxwsToolsVersion}") {
         exclude(group = "com.sun.xml.ws", module = "policy")


### PR DESCRIPTION
From https://github.com/advisories/GHSA-59j4-wjwp-mw9m

Litt usikker på om dette funker, ref Geir sitt forsøk i januar: https://github.com/navikt/isdialogmote/pull/402

CXF v4.0.2 har den riktige velocity-pakken, men da får man problemer mot opensaml 🤷🏼‍♂️

"Lever" i dev nå, men vi kan evt prøve å dytte til prod en dag og så sitte aktivt og følge med på om det blir noe feil (og om sårbarheten forsvinner, selvfølgelig).