### PR TITLE
IS-1867: Add eksternReferanseId to dokarkiv body

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.client.dokarkiv.domain
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
+import java.util.*
 
 const val JOURNALFORENDE_ENHET = 9999
 
@@ -35,6 +36,7 @@ data class JournalpostRequest private constructor(
     val tema: String,
     val kanal: String,
     val sak: Sak,
+    val eksternReferanseId: String,
 ) {
     companion object {
         fun create(
@@ -47,6 +49,7 @@ data class JournalpostRequest private constructor(
             tema: JournalpostTema,
             kanal: JournalpostKanal,
             sak: Sak,
+            eksternReferanseId: String,
         ) = JournalpostRequest(
             avsenderMottaker = avsenderMottaker,
             tittel = tittel,
@@ -57,6 +60,7 @@ data class JournalpostRequest private constructor(
             tema = tema.value,
             kanal = kanal.value,
             sak = sak,
+            eksternReferanseId = eksternReferanseId,
         )
     }
 }
@@ -71,6 +75,7 @@ fun createJournalpostRequest(
     dokumentName: String,
     dokumentPdf: ByteArray,
     kanal: JournalpostKanal? = null,
+    varselUuid: UUID,
 ): JournalpostRequest {
     val avsenderMottaker = AvsenderMottaker.create(
         id = mottakerPersonIdent?.value ?: mottakerVirksomhetsnummer?.value,
@@ -108,6 +113,7 @@ fun createJournalpostRequest(
         kanal = jpKanal,
         sak = sak,
         tema = JournalpostTema.OPPFOLGING,
+        eksternReferanseId = varselUuid.toString()
     )
 }
 

--- a/src/main/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
@@ -147,14 +147,14 @@ class DialogmoteVarselJournalforingCronjob(
                 val navn = pdlClient.navn(personIdent)
                 val pdf = pdfService.getPdf(referat.pdfId!!)
                 val moteTidspunkt = referatJournalpostService.getMotetidspunkt(referat.moteId)
-                val journalpostId = dokarkivClient.journalfor(
-                    journalpostRequest = referat.toJournalforingRequestArbeidstaker(
-                        personIdent = personIdent,
-                        navn = navn,
-                        pdf = pdf,
-                        moteTidspunkt = moteTidspunkt,
-                    )
-                )?.journalpostId
+                val journalpostRequest = referat.toJournalforingRequestArbeidstaker(
+                    personIdent = personIdent,
+                    navn = navn,
+                    pdf = pdf,
+                    moteTidspunkt = moteTidspunkt,
+                )
+                log.info("Journalfør referat to arbeidstaker with uuid ${referat.uuid} and eksternReferanseId: ${journalpostRequest.eksternReferanseId}")
+                val journalpostId = dokarkivClient.journalfor(journalpostRequest)?.journalpostId
 
                 journalpostId?.let { it ->
                     referatJournalpostService.updateJournalpostIdArbeidstakerForReferat(
@@ -179,15 +179,15 @@ class DialogmoteVarselJournalforingCronjob(
                 val virksomhetsnavn = eregClient.organisasjonVirksomhetsnavn(virksomhetsnummer)
                 val pdf = pdfService.getPdf(referat.pdfId!!)
                 val moteTidspunkt = referatJournalpostService.getMotetidspunkt(referat.moteId)
-                val journalpostId = dokarkivClient.journalfor(
-                    journalpostRequest = referat.toJournalforingRequestArbeidsgiver(
-                        brukerPersonIdent = personIdent,
-                        virksomhetsnummer = virksomhetsnummer,
-                        virksomhetsnavn = virksomhetsnavn?.virksomhetsnavn ?: "",
-                        pdf = pdf,
-                        moteTidspunkt = moteTidspunkt,
-                    )
-                )?.journalpostId
+                val journalpostRequest = referat.toJournalforingRequestArbeidsgiver(
+                    brukerPersonIdent = personIdent,
+                    virksomhetsnummer = virksomhetsnummer,
+                    virksomhetsnavn = virksomhetsnavn?.virksomhetsnavn ?: "",
+                    pdf = pdf,
+                    moteTidspunkt = moteTidspunkt,
+                )
+                log.info("Journalfør referat to arbeidsgiver with uuid ${referat.uuid} and eksternReferanseId: ${journalpostRequest.eksternReferanseId}")
+                val journalpostId = dokarkivClient.journalfor(journalpostRequest)?.journalpostId
 
                 journalpostId?.let { it ->
                     referatJournalpostService.updateJournalpostIdArbeidsgiverForReferat(
@@ -211,15 +211,15 @@ class DialogmoteVarselJournalforingCronjob(
             try {
                 val pdf = pdfService.getPdf(referat.pdfId!!)
                 val moteTidspunkt = referatJournalpostService.getMotetidspunkt(referat.moteId)
-                val journalpostId = dokarkivClient.journalfor(
-                    journalpostRequest = referat.toJournalforingRequestBehandler(
-                        brukerPersonIdent = personIdent,
-                        behandlerPersonIdent = behandler.personIdent,
-                        behandlerNavn = behandler.behandlerNavn,
-                        pdf = pdf,
-                        moteTidspunkt = moteTidspunkt,
-                    )
-                )?.journalpostId
+                val journalpostRequest = referat.toJournalforingRequestBehandler(
+                    brukerPersonIdent = personIdent,
+                    behandlerPersonIdent = behandler.personIdent,
+                    behandlerNavn = behandler.behandlerNavn,
+                    pdf = pdf,
+                    moteTidspunkt = moteTidspunkt,
+                )
+                log.info("Journalfør referat to behandler with uuid ${referat.uuid} and eksternReferanseId: ${journalpostRequest.eksternReferanseId}")
+                val journalpostId = dokarkivClient.journalfor(journalpostRequest)?.journalpostId
 
                 journalpostId?.let { it ->
                     referatJournalpostService.updateJournalpostIdBehandlerForReferat(

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidsgiverVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidsgiverVarsel.kt
@@ -83,4 +83,5 @@ fun DialogmotedeltakerArbeidsgiverVarsel.toJournalpostRequest(
     dokumentName = this.varselType.toJournalpostTittel(),
     brevkodeType = this.varselType.toBrevkodeType(DialogmoteDeltakerType.ARBEIDSGIVER),
     dokumentPdf = pdf,
+    varselUuid = this.uuid,
 )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidstakerVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerArbeidstakerVarsel.kt
@@ -88,4 +88,5 @@ fun DialogmotedeltakerArbeidstakerVarsel.toJournalpostRequest(
     dokumentName = this.varselType.toJournalpostTittel(),
     brevkodeType = this.varselType.toBrevkodeType(DialogmoteDeltakerType.ARBEIDSTAKER),
     dokumentPdf = pdf,
+    varselUuid = this.uuid,
 )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerBehandlerVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/DialogmotedeltakerBehandlerVarsel.kt
@@ -46,4 +46,5 @@ fun DialogmotedeltakerBehandlerVarsel.toJournalpostRequest(
     brevkodeType = this.varselType.toBrevkodeType(DialogmoteDeltakerType.BEHANDLER),
     dokumentPdf = pdf,
     kanal = JournalpostKanal.HELSENETTET,
+    varselUuid = this.uuid,
 )

--- a/src/main/kotlin/no/nav/syfo/dialogmote/domain/Referat.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/domain/Referat.kt
@@ -3,9 +3,7 @@ package no.nav.syfo.dialogmote.domain
 import no.nav.syfo.brev.arbeidstaker.domain.ArbeidstakerBrevDTO
 import no.nav.syfo.brev.domain.BrevType
 import no.nav.syfo.brev.narmesteleder.domain.NarmesteLederBrevDTO
-import no.nav.syfo.client.dokarkiv.domain.BrevkodeType
-import no.nav.syfo.client.dokarkiv.domain.JournalpostKanal
-import no.nav.syfo.client.dokarkiv.domain.createJournalpostRequest
+import no.nav.syfo.client.dokarkiv.domain.*
 import no.nav.syfo.dialogmote.api.domain.DialogmotedeltakerAnnenDTO
 import no.nav.syfo.dialogmote.api.domain.ReferatDTO
 import no.nav.syfo.domain.PersonIdent
@@ -107,6 +105,7 @@ fun Referat.toJournalforingRequestArbeidstaker(
     dokumentName = this.toJournalpostTittel(moteTidspunkt),
     brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_AT,
     dokumentPdf = pdf,
+    varselUuid = UUID.nameUUIDFromBytes((this.uuid.toString() + "arbeidstaker").toByteArray())
 )
 
 fun Referat.toJournalforingRequestArbeidsgiver(
@@ -123,6 +122,7 @@ fun Referat.toJournalforingRequestArbeidsgiver(
     dokumentName = this.toJournalpostTittel(moteTidspunkt),
     brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_AG,
     dokumentPdf = pdf,
+    varselUuid = UUID.nameUUIDFromBytes((this.uuid.toString() + "arbeidsgiver").toByteArray())
 )
 
 fun Referat.toJournalforingRequestBehandler(
@@ -140,6 +140,7 @@ fun Referat.toJournalforingRequestBehandler(
     brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_BEH,
     dokumentPdf = pdf,
     kanal = JournalpostKanal.HELSENETTET,
+    varselUuid = UUID.nameUUIDFromBytes((this.uuid.toString() + "behandler").toByteArray())
 )
 
 private val dateFormatterNorwegian = DateTimeFormatter.ofPattern("d. MMMM YYYY", Locale.forLanguageTag("no-NO"))

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -1,0 +1,83 @@
+package no.nav.syfo.client.dokarkiv
+
+import io.ktor.server.testing.*
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.client.azuread.AzureAdV2Client
+import no.nav.syfo.client.dokarkiv.domain.BrevkodeType
+import no.nav.syfo.client.dokarkiv.domain.JournalpostKanal
+import no.nav.syfo.client.person.kontaktinfo.KontaktinformasjonClient.Companion.CACHE_KONTAKTINFORMASJON_KEY_PREFIX
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.generator.generateJournalpostRequest
+import no.nav.syfo.testhelper.mock.DokarkivMock
+import no.nav.syfo.testhelper.mock.digitalKontaktinfoBolkKanVarslesTrue
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class DokarkivClientSpek : Spek({
+
+    val personIdent = UserConstants.ARBEIDSTAKER_FNR
+    val digitalKontaktInfo = digitalKontaktinfoBolkKanVarslesTrue(personIdent.value)
+    val digitalKontaktInfoCacheKey = "$CACHE_KONTAKTINFORMASJON_KEY_PREFIX${personIdent.value}"
+
+    val anyToken = "token"
+    val anyCallId = "callId"
+
+    describe("DokarkivClient") {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val azureAdV2ClientMock = mockk<AzureAdV2Client>(relaxed = true)
+            val dokarkivMock = DokarkivMock()
+            val dokarkivClient = DokarkivClient(
+                azureAdV2Client = azureAdV2ClientMock,
+                dokarkivClientId = "dokarkivClientId",
+                dokarkivBaseUrl = dokarkivMock.url,
+            )
+            val pdf = byteArrayOf(23)
+
+            beforeGroup {
+                dokarkivMock.server.start()
+            }
+
+            afterGroup {
+                dokarkivMock.server.stop(1L, 10L)
+            }
+
+            it("journalfører referat") {
+                val journalpostRequestReferat = generateJournalpostRequest(
+                    tittel = "Referat fra dialogmøte",
+                    brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_AT,
+                    pdf = pdf,
+                    kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                    varselId = UUID.randomUUID()
+                )
+
+                runBlocking {
+                    val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestReferat)
+
+                    response?.journalpostId shouldBeEqualTo 12345678
+                }
+            }
+
+            it("handles conflict from api when eksternRefeanseId exists by returning null") {
+                val journalpostRequestReferat = generateJournalpostRequest(
+                    tittel = "Referat fra dialogmøte",
+                    brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_AG,
+                    pdf = pdf,
+                    kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                    varselId = UserConstants.EXISTING_EKSTERN_REFERANSE_UUID,
+                )
+
+                runBlocking {
+                    val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestReferat)
+
+                    response shouldBeEqualTo null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.testhelper
 
 import no.nav.syfo.domain.*
+import java.util.*
 
 object UserConstants {
     val ARBEIDSTAKER_FNR = PersonIdent("12345678912")
@@ -43,6 +44,7 @@ object UserConstants {
     val OTHER_VIRKSOMHETSNUMMER_HAS_NARMESTELEDER = Virksomhetsnummer("922222223")
 
     val JOURNALPOST_ID_MOTTAKER_GONE = 129
+    val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
 
     val AZUREAD_TOKEN = "tokenReturnedByAzureAd"
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.client.dokarkiv.domain.*
+import no.nav.syfo.testhelper.UserConstants
+import java.util.*
+
+fun generateJournalpostRequest(
+    tittel: String,
+    brevkodeType: BrevkodeType,
+    pdf: ByteArray,
+    kanal: String,
+    varselId: UUID,
+) = JournalpostRequest.create(
+    avsenderMottaker = AvsenderMottaker.create(
+        id = UserConstants.ARBEIDSTAKER_FNR.value,
+        idType = BrukerIdType.PERSON_IDENT,
+        navn = UserConstants.ARBEIDSTAKERNAVN,
+    ),
+    bruker = Bruker.create(
+        id = UserConstants.ARBEIDSTAKER_FNR.value,
+        idType = BrukerIdType.PERSON_IDENT
+    ),
+    tittel = tittel,
+    dokumenter = listOf(
+        Dokument.create(
+            brevkode = brevkodeType,
+            tittel = tittel,
+            dokumentvarianter = listOf(
+                Dokumentvariant.create(
+                    filnavn = tittel,
+                    filtype = FiltypeType.PDFA,
+                    fysiskDokument = pdf,
+                    variantformat = VariantformatType.ARKIV,
+                )
+            ),
+        )
+    ),
+    kanal = JournalpostKanal.SENTRAL_UTSKRIFT,
+    journalfoerendeEnhet = null,
+    journalpostType = JournalpostType.UTGAAENDE,
+    tema = JournalpostTema.OPPFOLGING,
+    sak = Sak.invoke(SaksType.GENERELL),
+    eksternReferanseId = varselId.toString(),
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.request.*
@@ -11,6 +11,7 @@ import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.client.dokarkiv.DokarkivClient.Companion.JOURNALPOST_PATH
 import no.nav.syfo.client.dokarkiv.domain.JournalpostRequest
 import no.nav.syfo.client.dokarkiv.domain.JournalpostResponse
+import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_NO_JOURNALFORING
 import no.nav.syfo.testhelper.getRandomPort
 
@@ -29,7 +30,7 @@ class DokarkivMock {
     )
 
     private fun mockDokarkivServer(
-        port: Int
+        port: Int,
     ): NettyApplicationEngine {
         return embeddedServer(
             factory = Netty,
@@ -43,6 +44,8 @@ class DokarkivMock {
                         call.respond(HttpStatusCode.InternalServerError, "")
                     } else if (journalpostRequest.sak.sakstype.trim() == "") {
                         call.respond(HttpStatusCode.BadRequest, "")
+                    } else if (journalpostRequest.eksternReferanseId == UserConstants.EXISTING_EKSTERN_REFERANSE_UUID.toString()) {
+                        call.respond(HttpStatusCode.Conflict, "")
                     } else {
                         call.respond(journalpostResponse)
                     }


### PR DESCRIPTION
This will be required by dokarkiv 20. december.
If api receives an eksternReferanseId that is already stored, it will return 409 Conflict with the existing JournalPost as body. We want to fail when we get 409 becuase we don't want to journalføre the same varsel more than once. Since 409 gives clientException, the existing client returns null, which is then handled by the cron jobs.