### PR TITLE
IS-1973: Handle 409 conflict from dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -39,7 +39,13 @@ class DokarkivClient(
                 COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS.increment()
                 journalpostResponse
             } catch (e: ClientRequestException) {
-                handleUnexpectedResponseException(e.response, e.message)
+                if (e.response.status == HttpStatusCode.Conflict) {
+                    val journalpostResponse = e.response.body<JournalpostResponse>()
+                    log.warn("Journalpost med id ${journalpostResponse.journalpostId} lagret fra før (409 Conflict)")
+                    journalpostResponse
+                } else {
+                    handleUnexpectedResponseException(e.response, e.message)
+                }
             } catch (e: ServerResponseException) {
                 handleUnexpectedResponseException(e.response, e.message)
             }

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -42,6 +42,7 @@ class DokarkivClient(
                 if (e.response.status == HttpStatusCode.Conflict) {
                     val journalpostResponse = e.response.body<JournalpostResponse>()
                     log.warn("Journalpost med id ${journalpostResponse.journalpostId} lagret fra før (409 Conflict)")
+                    COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT.increment()
                     journalpostResponse
                 } else {
                     handleUnexpectedResponseException(e.response, e.message)

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
@@ -9,6 +9,7 @@ const val CALL_DOKARKIV_BASE = "${METRICS_NS}_call_dokarkiv"
 const val CALL_DOKARKIV_JOURNALPOST_BASE = "${CALL_DOKARKIV_BASE}_journalpost"
 const val CALL_DOKARKIV_JOURNALPOST_SUCCESS = "${CALL_DOKARKIV_JOURNALPOST_BASE}_success_count"
 const val CALL_DOKARKIV_JOURNALPOST_FAIL = "${CALL_DOKARKIV_JOURNALPOST_BASE}_fail_count"
+const val CALL_DOKARKIV_JOURNALPOST_CONFLICT = "${CALL_DOKARKIV_JOURNALPOST_BASE}_conflict_count"
 
 val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_SUCCESS)
@@ -17,4 +18,8 @@ val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
 val COUNT_CALL_DOKARKIV_JOURNALPOST_FAIL: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_FAIL)
     .description("Counts the number of failed calls to Dokarkiv - Journalpost")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT: Counter = Counter
+    .builder(CALL_DOKARKIV_JOURNALPOST_CONFLICT)
+    .description("Counts the number of calls to Dokarkiv - Journalpost resulting in 409 Conflict")
     .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -6,24 +6,15 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.client.azuread.AzureAdV2Client
 import no.nav.syfo.client.dokarkiv.domain.BrevkodeType
 import no.nav.syfo.client.dokarkiv.domain.JournalpostKanal
-import no.nav.syfo.client.person.kontaktinfo.KontaktinformasjonClient.Companion.CACHE_KONTAKTINFORMASJON_KEY_PREFIX
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generator.generateJournalpostRequest
 import no.nav.syfo.testhelper.mock.DokarkivMock
-import no.nav.syfo.testhelper.mock.digitalKontaktinfoBolkKanVarslesTrue
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.*
 
 class DokarkivClientSpek : Spek({
-
-    val personIdent = UserConstants.ARBEIDSTAKER_FNR
-    val digitalKontaktInfo = digitalKontaktinfoBolkKanVarslesTrue(personIdent.value)
-    val digitalKontaktInfoCacheKey = "$CACHE_KONTAKTINFORMASJON_KEY_PREFIX${personIdent.value}"
-
-    val anyToken = "token"
-    val anyCallId = "callId"
 
     describe("DokarkivClient") {
 
@@ -59,11 +50,11 @@ class DokarkivClientSpek : Spek({
                 runBlocking {
                     val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestReferat)
 
-                    response?.journalpostId shouldBeEqualTo 12345678
+                    response?.journalpostId shouldBeEqualTo UserConstants.JOURNALPOSTID_JOURNALFORING
                 }
             }
 
-            it("handles conflict from api when eksternRefeanseId exists by returning null") {
+            it("handles conflict from api when eksternRefeanseId exists by returning journalpostid") {
                 val journalpostRequestReferat = generateJournalpostRequest(
                     tittel = "Referat fra dialogmøte",
                     brevkodeType = BrevkodeType.DIALOGMOTE_REFERAT_AG,
@@ -75,7 +66,7 @@ class DokarkivClientSpek : Spek({
                 runBlocking {
                     val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestReferat)
 
-                    response shouldBeEqualTo null
+                    response?.journalpostId shouldBeEqualTo UserConstants.JOURNALPOSTID_JOURNALFORING
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -44,6 +44,7 @@ object UserConstants {
     val OTHER_VIRKSOMHETSNUMMER_HAS_NARMESTELEDER = Virksomhetsnummer("922222223")
 
     val JOURNALPOST_ID_MOTTAKER_GONE = 129
+    val JOURNALPOSTID_JOURNALFORING = 12345678
     val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
 
     val AZUREAD_TOKEN = "tokenReturnedByAzureAd"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -19,8 +19,8 @@ class DokarkivMock {
     private val port = getRandomPort()
     val url = "http://localhost:$port"
 
-    val journalpostResponse = JournalpostResponse(
-        journalpostId = 12345678,
+    private val journalpostResponse = JournalpostResponse(
+        journalpostId = UserConstants.JOURNALPOSTID_JOURNALFORING,
         journalstatus = "journalstatus",
     )
 
@@ -45,7 +45,7 @@ class DokarkivMock {
                     } else if (journalpostRequest.sak.sakstype.trim() == "") {
                         call.respond(HttpStatusCode.BadRequest, "")
                     } else if (journalpostRequest.eksternReferanseId == UserConstants.EXISTING_EKSTERN_REFERANSE_UUID.toString()) {
-                        call.respond(HttpStatusCode.Conflict, "")
+                        call.respond(HttpStatusCode.Conflict, journalpostResponse)
                     } else {
                         call.respond(journalpostResponse)
                     }


### PR DESCRIPTION
409 fra Dokarkiv betyr at journalpost allerede er opprettet og vi kan håndtere dette ved å lagre journalpostIden vi får fra responsen.

