### PR TITLE
IS-1947: Add endpoint to assign dialogmote to other veileder

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -463,7 +463,7 @@ class DialogmoteService(
         }
     }
 
-    fun overtaMoter(veilederIdent: String, dialogmoter: List<Dialogmote>) {
+    fun tildelMoter(veilederIdent: String, dialogmoter: List<Dialogmote>) {
         database.connection.use { connection ->
             dialogmoter.forEach { dialogmote ->
                 connection.updateMoteTildeltVeileder(

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/TildelDialogmoterDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/TildelDialogmoterDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.dialogmote.api.domain
+
+import java.util.UUID
+
+data class TildelDialogmoterDTO(
+    val veilederIdent: String,
+    val dialogmoteUuids: List<UUID>,
+)

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/v2/DialogmoteActionsApiV2.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/v2/DialogmoteActionsApiV2.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.dialogmote.api.v2
 
-import io.ktor.server.application.*
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -9,7 +9,10 @@ import no.nav.syfo.application.api.authentication.getNAVIdentFromToken
 import no.nav.syfo.dialogmote.DialogmoteService
 import no.nav.syfo.dialogmote.api.domain.*
 import no.nav.syfo.dialogmote.tilgang.DialogmoteTilgangService
-import no.nav.syfo.util.*
+import no.nav.syfo.util.callIdArgument
+import no.nav.syfo.util.getBearerHeader
+import no.nav.syfo.util.getCallId
+import no.nav.syfo.util.validateVeilederAccess
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -191,7 +194,7 @@ fun Route.registerDialogmoteActionsApiV2(
             }
         }
 
-        post(dialogmoteTildelPath) {
+        patch(dialogmoteTildelPath) {
             val callId = getCallId()
             try {
                 val token = getBearerHeader()
@@ -210,7 +213,7 @@ fun Route.registerDialogmoteActionsApiV2(
                     )
                 ) {
                     dialogmoteService.tildelMoter(veilederIdent, dialogmoter)
-                    call.respond(HttpStatusCode.OK)
+                    call.respond(HttpStatusCode.NoContent)
                 } else {
                     val accessDeniedMessage = "Denied veileder access to dialogmøter for person with PersonIdent"
                     log.warn("$accessDeniedMessage, {}", callIdArgument(callId))

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
@@ -5,10 +5,15 @@ import no.nav.syfo.application.database.toList
 import no.nav.syfo.cronjob.statusendring.toInstantOslo
 import no.nav.syfo.dialogmote.database.domain.PDialogmote
 import no.nav.syfo.dialogmote.database.domain.PMotedeltakerBehandlerVarsel
-import no.nav.syfo.dialogmote.domain.*
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import no.nav.syfo.dialogmote.domain.NewDialogmote
+import no.nav.syfo.dialogmote.domain.TidStedDTO
 import no.nav.syfo.domain.EnhetNr
 import no.nav.syfo.domain.PersonIdent
-import java.sql.*
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.*
@@ -135,12 +140,12 @@ data class CreatedDialogmoteIdentifiers(
 )
 
 fun Connection.createNewDialogmoteWithReferences(
-    commit: Boolean = true,
     newDialogmote: NewDialogmote,
+    commit: Boolean = true,
 ): CreatedDialogmoteIdentifiers {
     val moteIdList = this.createDialogmote(
+        newDialogmote = newDialogmote,
         commit = false,
-        newDialogmote = newDialogmote
     )
 
     val moteId = moteIdList.first
@@ -181,8 +186,8 @@ fun Connection.createNewDialogmoteWithReferences(
 }
 
 fun Connection.createDialogmote(
+    newDialogmote: NewDialogmote,
     commit: Boolean = true,
-    newDialogmote: NewDialogmote
 ): Pair<Int, UUID> {
     val moteUuid = UUID.randomUUID()
     val now = Timestamp.from(Instant.now())

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/TildelDialogmoteApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/TildelDialogmoteApiV2Spek.kt
@@ -18,7 +18,6 @@ import no.nav.syfo.dialogmote.api.domain.TildelDialogmoterDTO
 import no.nav.syfo.dialogmote.database.createNewDialogmoteWithReferences
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.generator.generateNewDialogmote
-import no.nav.syfo.testhelper.generator.generateNewDialogmoteDTO
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.shouldBeEqualTo
@@ -75,31 +74,14 @@ class TildelDialogmoteApiV2Spek : Spek({
                 val urlMote = "$dialogmoteApiV2Basepath$dialogmoteApiPersonIdentUrlPath"
                 val urlMoterEnhet = "$dialogmoteApiV2Basepath$dialogmoteApiEnhetUrlPath/${UserConstants.ENHET_NR.value}"
                 val urlTildelMote = "$dialogmoteApiV2Basepath$dialogmoteTildelPath"
-                val newDialogmoteDTO = generateNewDialogmoteDTO(UserConstants.ARBEIDSTAKER_FNR)
-                val newDialogmoteDTOAnnenArbeidstaker = generateNewDialogmoteDTO(UserConstants.ARBEIDSTAKER_ANNEN_FNR)
+                val newDialogmote = generateNewDialogmote(UserConstants.ARBEIDSTAKER_FNR)
+                val newDialogmoteAnnenArbeidstaker = generateNewDialogmote(UserConstants.ARBEIDSTAKER_ANNEN_FNR)
 
                 describe("Happy path") {
                     it("should tildele dialogmoter if request is successful") {
                         val createdDialogmoterUuids = mutableListOf<UUID>()
-
-                        with(
-                            handleRequest(HttpMethod.Post, urlMote) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(veilederCallerToken))
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                        }
-                        with(
-                            handleRequest(HttpMethod.Post, urlMote) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(veilederCallerToken))
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                setBody(objectMapper.writeValueAsString(newDialogmoteDTOAnnenArbeidstaker))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                        }
+                        database.connection.run { this.createNewDialogmoteWithReferences(newDialogmote) }
+                        database.connection.run { this.createNewDialogmoteWithReferences(newDialogmoteAnnenArbeidstaker) }
 
                         with(
                             handleRequest(HttpMethod.Get, urlMoterEnhet) {
@@ -209,16 +191,7 @@ class TildelDialogmoteApiV2Spek : Spek({
 
                     it("should return status Forbidden if contains dialogmøte with denied access to person") {
                         val createdDialogmoterUuids = mutableListOf<UUID>()
-
-                        with(
-                            handleRequest(HttpMethod.Post, urlMote) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(veilederCallerToken))
-                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                                setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                        }
+                        database.connection.run { this.createNewDialogmoteWithReferences(newDialogmote) }
 
                         with(
                             handleRequest(HttpMethod.Get, urlMoterEnhet) {


### PR DESCRIPTION
- Legger til endepunkt som gjør det mulig å tildele en annen veileder dialogmøter
- Et spørsmål er om vi også bør sjekke tilgang til veileder som skal få tildelt møter. I så fall kan det se ut som vi må legge til funksjonalitet i `istilgangskontroll` for å sjekke tilgang basert på en `veilederIdent` og ikke bare token som vi gjør i dag.