### PR TITLE
Remove access policy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -57,9 +57,6 @@ spec:
         - application: dialogmote-frontend
           namespace: team-esyfo
           cluster: dev-gcp
-        - application: ditt-sykefravaer
-          namespace: flex
-          cluster: dev-gcp
         - application: esyfo-proxy
           namespace: team-esyfo
           cluster: dev-gcp

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -58,9 +58,6 @@ spec:
         - application: dialogmote-frontend
           namespace: team-esyfo
           cluster: prod-gcp
-        - application: ditt-sykefravaer
-          namespace: flex
-          cluster: prod-gcp
         - application: esyfo-proxy
           namespace: team-esyfo
           cluster: prod-gcp


### PR DESCRIPTION
isdialogmote er fjernet fra outbound access policies i [ditt-sykefravaer](https://github.com/navikt/ditt-sykefravaer/pull/964/files) så fjerner inbound her