### PR TITLE
IS-2319: Delete erronous dialogmote avlysning

### DIFF
--- a/src/main/resources/db/migration/V9_08__delete_avlysning.sql
+++ b/src/main/resources/db/migration/V9_08__delete_avlysning.sql
@@ -1,0 +1,19 @@
+DELETE
+FROM motedeltaker_arbeidstaker_varsel
+WHERE id = '221126';
+
+DELETE
+FROM motedeltaker_arbeidsgiver_varsel
+WHERE id = '221126';
+
+DELETE
+FROM mote_status_endret
+WHERE id = '304416';
+
+DELETE
+FROM pdf
+WHERE id IN ('678784', '678785');
+
+UPDATE mote
+SET status = 'INNKALT'
+WHERE id = '127415';


### PR DESCRIPTION
Sletter dialogmøte avlysning.
- Sletter varsel til arbeidstaker
- Sletter varsel til arbeidsgiver
- Ser ikke ut som det har gått ut varsel til behandler
- Endrer status på mote til `INNKALT`.
- Sletter innslag som registrerer `AVLYSNING` i `mote_status_endret`
- Sletter pdf'er som er generert i forbindelse med avlysningen

Sjekk konsumenter av dialogmote endring topic. Sjekket veldig kjapt `isdialogmotekandidat`, `syfooversiktsrv`, `syfomotebehov`, `ispersonoppgave`. Ikke åpenbart at noe blir krøll.

- [x] Dobbeltsjekk med Stine at dette blir riktig