### PR TITLE
IS-2241: Setup consumer for janitor event and produce event status

### DIFF
--- a/src/main/kotlin/no/nav/syfo/janitor/JanitorService.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/JanitorService.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.janitor
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.dialogmote.DialogmoterelasjonService
+import no.nav.syfo.dialogmote.DialogmotestatusService
+import no.nav.syfo.dialogmote.database.getDialogmote
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import no.nav.syfo.dialogmote.domain.unfinished
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.janitor.kafka.*
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class JanitorService(
+    private val database: DatabaseInterface,
+    private val dialogmotestatusService: DialogmotestatusService,
+    private val dialogmoterelasjonService: DialogmoterelasjonService,
+    private val janitorEventStatusProducer: JanitorEventStatusProducer,
+) {
+    suspend fun handle(event: JanitorEventDTO) {
+        log.info("Received janitor event ${event.action} with reference ${event.referenceUUID}")
+        when (event.action) {
+            JanitorAction.LUKK_DIALOGMOTE.name -> {
+                val result = handleLukk(event)
+                result.onFailure { log.error("Failed to handle janitor event", it) }
+                sendEventStatus(event, result)
+            }
+            else -> log.trace("Irrelevant janitor event")
+        }
+    }
+
+    private suspend fun handleLukk(event: JanitorEventDTO): Result<Unit> = runCatching {
+        val personIdent = PersonIdent(event.personident)
+        val dialogmoteUUID = UUID.fromString(event.referenceUUID)
+        val pDialogmote = database.getDialogmote(moteUUID = dialogmoteUUID).firstOrNull() ?: throw RuntimeException(
+            "Fant ikke dialogmøte"
+        )
+        val dialogmote =
+            dialogmoterelasjonService.extendDialogmoteRelations(pDialogmote).takeIf { it.status.unfinished() }
+                ?: throw RuntimeException("Dialogmøte ikke aktivt")
+        if (dialogmote.arbeidstaker.personIdent != personIdent) {
+            throw RuntimeException("Dialogmote gjelder ikke person")
+        }
+
+        log.info("Lukker dialogmøte med uuid $dialogmoteUUID")
+        database.connection.use { connection ->
+            dialogmotestatusService.updateMoteStatus(
+                connection = connection,
+                dialogmote = dialogmote,
+                newDialogmoteStatus = DialogmoteStatus.LUKKET,
+                opprettetAv = event.navident,
+            )
+            connection.commit()
+        }
+    }
+
+    private fun sendEventStatus(event: JanitorEventDTO, result: Result<Unit>) {
+        janitorEventStatusProducer.sendEventStatus(
+            eventStatus = JanitorEventStatusDTO(
+                eventUUID = event.eventUUID,
+                status = if (result.isSuccess) JanitorEventStatus.OK else JanitorEventStatus.FAILED,
+            )
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumer.kt
@@ -1,0 +1,46 @@
+package no.nav.syfo.janitor.kafka
+
+import kotlinx.coroutines.delay
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.janitor.JanitorService
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class JanitorEventConsumer(
+    private val kafkaConsumer: KafkaConsumer<String, JanitorEventDTO>,
+    private val applicationState: ApplicationState,
+    private val janitorService: JanitorService,
+) {
+    suspend fun startConsumer() {
+        kafkaConsumer.subscribe(listOf(JANITOR_EVENT_TOPIC))
+        log.info("Started consuming $JANITOR_EVENT_TOPIC topic")
+        while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(JANITOR_EVENT_TOPIC))
+            }
+            try {
+                val records = kafkaConsumer.poll(Duration.ofSeconds(POLL_DURATION_SECONDS))
+                if (records.count() > 0) {
+                    records.requireNoNulls().forEach { record ->
+                        janitorService.handle(record.value())
+                    }
+                    kafkaConsumer.commitSync()
+                }
+            } catch (ex: Exception) {
+                log.warn("Error running kafka consumer for $JANITOR_EVENT_TOPIC, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
+                kafkaConsumer.unsubscribe()
+                delay(DELAY_ON_ERROR_SECONDS.seconds)
+            }
+        }
+    }
+
+    companion object {
+        const val JANITOR_EVENT_TOPIC = "teamsykefravr.syfojanitor-event"
+        private const val POLL_DURATION_SECONDS = 10L
+        private const val DELAY_ON_ERROR_SECONDS = 60L
+        private val log: Logger = LoggerFactory.getLogger(JanitorEventConsumer::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumerConfig.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.janitor.kafka
+
+import no.nav.syfo.application.ApplicationEnvironmentKafka
+import no.nav.syfo.application.kafka.commonKafkaAivenConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.*
+
+fun kafkaJanitorEventConsumerConfig(
+    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(applicationEnvironmentKafka))
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isdialogmote-v1"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JanitorEventDeserializer::class.java.canonicalName
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventConsumerConfig.kt
@@ -14,7 +14,7 @@ fun kafkaJanitorEventConsumerConfig(
         this[ConsumerConfig.GROUP_ID_CONFIG] = "isdialogmote-v1"
         this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JanitorEventDeserializer::class.java.canonicalName
-        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
         this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
         this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
         this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventDTO.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.janitor.kafka
+
+data class JanitorEventDTO(
+    val referenceUUID: String,
+    val navident: String,
+    val eventUUID: String,
+    val personident: String,
+    val action: String,
+)
+
+enum class JanitorAction {
+    LUKK_DIALOGMOTE
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventDeserializer.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventDeserializer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.janitor.kafka
+
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Deserializer
+
+val mapper = configuredJacksonMapper()
+
+class JanitorEventDeserializer : Deserializer<JanitorEventDTO> {
+    override fun deserialize(topic: String?, data: ByteArray?): JanitorEventDTO =
+        mapper.readValue(data, JanitorEventDTO::class.java)
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusDTO.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.janitor.kafka
+
+data class JanitorEventStatusDTO(
+    val eventUUID: String,
+    val status: JanitorEventStatus,
+)
+
+enum class JanitorEventStatus {
+    CREATED,
+    OK,
+    FAILED,
+}

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusDTO.kt
@@ -6,7 +6,6 @@ data class JanitorEventStatusDTO(
 )
 
 enum class JanitorEventStatus {
-    CREATED,
     OK,
     FAILED,
 }

--- a/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/janitor/kafka/JanitorEventStatusProducer.kt
@@ -1,0 +1,32 @@
+package no.nav.syfo.janitor.kafka
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+
+class JanitorEventStatusProducer(
+    private val kafkaProducer: KafkaProducer<String, JanitorEventStatusDTO>,
+) {
+    fun sendEventStatus(
+        eventStatus: JanitorEventStatusDTO,
+    ) {
+        try {
+            kafkaProducer.send(
+                ProducerRecord(
+                    JANITOR_EVENT_STATUS,
+                    eventStatus.eventUUID,
+                    eventStatus,
+                )
+            ).get()
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to send JanitorEventStatusDTO with id {}: ${e.message}", eventStatus.eventUUID)
+            throw e
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java)
+
+        const val JANITOR_EVENT_STATUS = "teamsykefravr.syfojanitor-status"
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/janitor/JanitorServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/janitor/JanitorServiceSpek.kt
@@ -1,0 +1,230 @@
+package no.nav.syfo.janitor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.http.*
+import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.altinn.schemas.services.intermediary.receipt._2009._10.ReceiptExternal
+import no.altinn.schemas.services.intermediary.receipt._2009._10.ReceiptStatusEnum
+import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasic
+import no.nav.syfo.brev.esyfovarsel.EsyfovarselProducer
+import no.nav.syfo.dialogmote.DialogmotedeltakerService
+import no.nav.syfo.dialogmote.DialogmoterelasjonService
+import no.nav.syfo.dialogmote.DialogmotestatusService
+import no.nav.syfo.dialogmote.api.v2.dialogmoteApiMoteFerdigstillPath
+import no.nav.syfo.dialogmote.api.v2.dialogmoteApiPersonIdentUrlPath
+import no.nav.syfo.dialogmote.api.v2.dialogmoteApiV2Basepath
+import no.nav.syfo.dialogmote.database.getDialogmoteList
+import no.nav.syfo.dialogmote.database.getMoteStatusEndretNotPublished
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import no.nav.syfo.janitor.kafka.*
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.generateNewDialogmoteDTO
+import no.nav.syfo.testhelper.generator.generateNewReferatDTO
+import no.nav.syfo.util.bearerHeader
+import no.nav.syfo.util.configuredJacksonMapper
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.UUID
+
+fun generateJanitorEventDTO(action: String, referenceUuid: String): JanitorEventDTO = JanitorEventDTO(
+    referenceUUID = referenceUuid,
+    navident = UserConstants.VEILEDER_IDENT,
+    eventUUID = UUID.randomUUID().toString(),
+    personident = UserConstants.ARBEIDSTAKER_FNR.value,
+    action = action,
+)
+
+val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+class JanitorServiceSpek : Spek({
+
+    describe(JanitorService::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment.getInstance()
+            val database = externalMockEnvironment.database
+            val altinnMock = mockk<ICorrespondenceAgencyExternalBasic>()
+            val esyfovarselProducerMock = mockk<EsyfovarselProducer>(relaxed = true)
+            justRun { esyfovarselProducerMock.sendVarselToEsyfovarsel(any()) }
+            val eventStatusProducerMock = mockk<JanitorEventStatusProducer>(relaxed = true)
+            justRun { eventStatusProducerMock.sendEventStatus(any()) }
+
+            val dialogmotestatusService = DialogmotestatusService(oppfolgingstilfelleClient = mockk(relaxed = true))
+            val dialogmotedeltakerService =
+                DialogmotedeltakerService(database = database, arbeidstakerVarselService = mockk())
+            val dialogmoterelasjonService = DialogmoterelasjonService(
+                database = database,
+                dialogmotedeltakerService = dialogmotedeltakerService,
+            )
+
+            val janitorService = JanitorService(
+                database = database,
+                dialogmotestatusService = dialogmotestatusService,
+                dialogmoterelasjonService = dialogmoterelasjonService,
+                janitorEventStatusProducer = eventStatusProducerMock,
+            )
+
+            application.testApiModule(
+                externalMockEnvironment = externalMockEnvironment,
+                behandlerVarselService = mockk(),
+                altinnMock = altinnMock,
+                esyfovarselProducer = esyfovarselProducerMock,
+            )
+
+            beforeEachTest {
+                val altinnResponse = ReceiptExternal()
+                altinnResponse.receiptStatusCode = ReceiptStatusEnum.OK
+
+                clearMocks(altinnMock)
+                clearMocks(eventStatusProducerMock)
+
+                every {
+                    altinnMock.insertCorrespondenceBasicV2(any(), any(), any(), any(), any())
+                } returns altinnResponse
+            }
+
+            afterEachTest {
+                database.dropData()
+            }
+
+            describe("Handles lukk møte event") {
+                val validToken = generateJWTNavIdent(
+                    externalMockEnvironment.environment.aadAppClient,
+                    externalMockEnvironment.wellKnownVeilederV2.issuer,
+                    UserConstants.VEILEDER_IDENT,
+                )
+                val urlMote = "$dialogmoteApiV2Basepath$dialogmoteApiPersonIdentUrlPath"
+
+                it("updates motestatus to LUKKET and produces event status OK") {
+                    val newDialogmoteDTO = generateNewDialogmoteDTO(
+                        personIdent = UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    with(
+                        handleRequest(HttpMethod.Post, urlMote) {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                    }
+
+                    val mote = database.getDialogmoteList(UserConstants.ARBEIDSTAKER_FNR).first()
+
+                    val event = generateJanitorEventDTO(
+                        action = JanitorAction.LUKK_DIALOGMOTE.name,
+                        referenceUuid = mote.uuid.toString()
+                    )
+                    runBlocking { janitorService.handle(event) }
+
+                    val motestatusList = database.getMoteStatusEndretNotPublished()
+                    motestatusList.shouldNotBeEmpty()
+                    val motestatus = motestatusList.last()
+                    motestatus.status shouldBeEqualTo DialogmoteStatus.LUKKET
+                    motestatus.opprettetAv shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                    motestatus.moteId shouldBeEqualTo mote.id
+
+                    verify { eventStatusProducerMock.sendEventStatus(JanitorEventStatusDTO(eventUUID = event.eventUUID, status = JanitorEventStatus.OK)) }
+                }
+
+                it("produces event status FAILED if mote not found") {
+                    val event = generateJanitorEventDTO(
+                        action = JanitorAction.LUKK_DIALOGMOTE.name,
+                        referenceUuid = UUID.randomUUID().toString()
+                    )
+                    runBlocking { janitorService.handle(event) }
+
+                    verify { eventStatusProducerMock.sendEventStatus(JanitorEventStatusDTO(eventUUID = event.eventUUID, status = JanitorEventStatus.FAILED)) }
+                }
+
+                it("produces event status FAILED if mote finished") {
+                    val newDialogmoteDTO = generateNewDialogmoteDTO(
+                        personIdent = UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    with(
+                        handleRequest(HttpMethod.Post, urlMote) {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                    }
+
+                    val mote = database.getDialogmoteList(UserConstants.ARBEIDSTAKER_FNR).first()
+                    val moteUuid = mote.uuid
+
+                    with(
+                        handleRequest(
+                            HttpMethod.Post,
+                            "$dialogmoteApiV2Basepath/${moteUuid}$dialogmoteApiMoteFerdigstillPath"
+                        ) {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            setBody(objectMapper.writeValueAsString(generateNewReferatDTO()))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                    }
+
+                    val event = generateJanitorEventDTO(
+                        action = JanitorAction.LUKK_DIALOGMOTE.name,
+                        referenceUuid = moteUuid.toString()
+                    )
+
+                    runBlocking { janitorService.handle(event) }
+
+                    verify { eventStatusProducerMock.sendEventStatus(JanitorEventStatusDTO(eventUUID = event.eventUUID, status = JanitorEventStatus.FAILED)) }
+                }
+
+                it("produces event status FAILED if mote on wrong person") {
+                    val newDialogmoteDTO = generateNewDialogmoteDTO(
+                        personIdent = UserConstants.ARBEIDSTAKER_FNR,
+                    )
+                    with(
+                        handleRequest(HttpMethod.Post, urlMote) {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            setBody(objectMapper.writeValueAsString(newDialogmoteDTO))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                    }
+
+                    val mote = database.getDialogmoteList(UserConstants.ARBEIDSTAKER_FNR).first()
+                    val event = generateJanitorEventDTO(
+                        action = JanitorAction.LUKK_DIALOGMOTE.name,
+                        referenceUuid = mote.uuid.toString()
+                    ).copy(personident = UserConstants.ARBEIDSTAKER_ANNEN_FNR.value)
+
+                    runBlocking { janitorService.handle(event) }
+
+                    verify { eventStatusProducerMock.sendEventStatus(JanitorEventStatusDTO(eventUUID = event.eventUUID, status = JanitorEventStatus.FAILED)) }
+                }
+            }
+
+            describe("Handles irrelevant event") {
+                it("does not update mote status or produce event status") {
+                    runBlocking {
+                        janitorService.handle(
+                            generateJanitorEventDTO(
+                                "IRRELEVANT_ACTION",
+                                UUID.randomUUID().toString()
+                            )
+                        )
+                    }
+
+                    database.getMoteStatusEndretNotPublished().shouldBeEmpty()
+                    verify(exactly = 0) { eventStatusProducerMock.sendEventStatus(any()) }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Lager ny PR på å starte opp consumeren i App.kt (krever en del refaktorering/flytting av services som den er avhengig av)