### PR TITLE
Use db-isolation leve READ_COMMITTED

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -31,7 +31,7 @@ class Database(
             maximumPoolSize = daoConfig.poolSize
             minimumIdle = 1
             isAutoCommit = false
-            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            transactionIsolation = "TRANSACTION_READ_COMMITTED"
             metricsTrackerFactory = PrometheusMetricsTrackerFactory(METRICS_REGISTRY.prometheusRegistry)
             validate()
         }


### PR DESCRIPTION
Med denne tilpasningen bør vi unngå feil av typen "org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update"