### PR TITLE
IS-1879: Add api for dialogmote statusendringer

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -38,6 +38,7 @@ import no.nav.syfo.dialogmelding.kafka.kafkaDialogmeldingConsumerConfig
 import no.nav.syfo.dialogmote.DialogmotedeltakerService
 import no.nav.syfo.dialogmote.DialogmoterelasjonService
 import no.nav.syfo.dialogmote.DialogmotestatusService
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.identhendelse.IdenthendelseService
 import no.nav.syfo.identhendelse.kafka.IdenthendelseConsumerService
 import no.nav.syfo.identhendelse.kafka.kafkaIdenthendelseConsumerConfig
@@ -105,10 +106,10 @@ fun main() {
         isoppfolgingstilfelleClientId = environment.isoppfolgingstilfelleClientId,
         cache = cache,
     )
-    val dialogmotestatusService = DialogmotestatusService(oppfolgingstilfelleClient = oppfolgingstilfelleClient)
 
     lateinit var behandlerVarselService: BehandlerVarselService
     lateinit var dialogmoterelasjonService: DialogmoterelasjonService
+    lateinit var dialogmotestatusService: DialogmotestatusService
 
     val applicationEngineEnvironment = applicationEngineEnvironment {
         log = logger
@@ -134,6 +135,13 @@ fun main() {
             dialogmoterelasjonService = DialogmoterelasjonService(
                 database = applicationDatabase,
                 dialogmotedeltakerService = dialogmotedeltakerService
+            )
+            val moteStatusEndretRepository = MoteStatusEndretRepository(
+                database = applicationDatabase,
+            )
+            dialogmotestatusService = DialogmotestatusService(
+                oppfolgingstilfelleClient = oppfolgingstilfelleClient,
+                moteStatusEndretRepository = moteStatusEndretRepository,
             )
 
             apiModule(

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -30,7 +30,7 @@ import no.nav.syfo.dialogmote.*
 import no.nav.syfo.dialogmote.api.v2.registerDialogmoteActionsApiV2
 import no.nav.syfo.dialogmote.api.v2.registerDialogmoteApiV2
 import no.nav.syfo.dialogmote.api.v2.registerDialogmoteEnhetApiV2
-import no.nav.syfo.dialogmote.database.MoteRepository
+import no.nav.syfo.dialogmote.database.repository.MoteRepository
 import no.nav.syfo.dialogmote.tilgang.DialogmoteTilgangService
 
 fun Application.apiModule(
@@ -177,6 +177,7 @@ fun Application.apiModule(
             registerDialogmoteApiV2(
                 dialogmoteService = dialogmoteService,
                 dialogmoteTilgangService = dialogmoteTilgangService,
+                dialogmotestatusService = dialogmotestatusService,
             )
             registerDialogmoteActionsApiV2(
                 dialogmoteService = dialogmoteService,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmoteService.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.client.person.kontaktinfo.KontaktinformasjonClient
 import no.nav.syfo.dialogmote.api.domain.*
 import no.nav.syfo.dialogmote.database.*
 import no.nav.syfo.dialogmote.database.domain.toReferat
+import no.nav.syfo.dialogmote.database.repository.MoteRepository
 import no.nav.syfo.dialogmote.domain.*
 import no.nav.syfo.domain.EnhetNr
 import no.nav.syfo.domain.PersonIdent

--- a/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotestatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/DialogmotestatusService.kt
@@ -1,7 +1,9 @@
 package no.nav.syfo.dialogmote
 
 import no.nav.syfo.client.oppfolgingstilfelle.OppfolgingstilfelleClient
+import no.nav.syfo.dialogmote.api.domain.DialogmoteStatusEndringDTO
 import no.nav.syfo.dialogmote.database.createMoteStatusEndring
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.dialogmote.database.updateMoteStatus
 import no.nav.syfo.dialogmote.domain.*
 import no.nav.syfo.domain.PersonIdent
@@ -9,6 +11,7 @@ import java.sql.Connection
 
 class DialogmotestatusService(
     private val oppfolgingstilfelleClient: OppfolgingstilfelleClient,
+    private val moteStatusEndretRepository: MoteStatusEndretRepository,
 ) {
 
     suspend fun updateMoteStatus(
@@ -70,6 +73,9 @@ class DialogmotestatusService(
         callId = callId,
         token = token,
     )
+
+    fun getMoteStatusEndringer(personident: PersonIdent): List<DialogmoteStatusEndringDTO> =
+        moteStatusEndretRepository.getMoteStatusEndringer(personident)
 
     private suspend fun createMoteStatusEndring(
         connection: Connection,

--- a/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/DialogmoteStatusEndringDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/api/domain/DialogmoteStatusEndringDTO.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.dialogmote.api.domain
+
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import java.time.LocalDateTime
+
+data class DialogmoteStatusEndringDTO(
+    val uuid: String,
+    val createdAt: LocalDateTime,
+    val dialogmoteId: Int,
+    val dialogmoteOpprettetAv: String,
+    val status: DialogmoteStatus,
+    val statusEndringOpprettetAv: String,
+)

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/MoteQuery.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.application.database.toList
 import no.nav.syfo.cronjob.statusendring.toInstantOslo
 import no.nav.syfo.dialogmote.database.domain.PDialogmote
 import no.nav.syfo.dialogmote.database.domain.PMotedeltakerBehandlerVarsel
+import no.nav.syfo.dialogmote.database.repository.toPDialogmote
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.dialogmote.domain.NewDialogmote
 import no.nav.syfo.dialogmote.domain.TidStedDTO

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/repository/MoteRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/repository/MoteRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.dialogmote.database
+package no.nav.syfo.dialogmote.database.repository
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.database.toList

--- a/src/main/kotlin/no/nav/syfo/dialogmote/database/repository/MoteStatusEndretRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmote/database/repository/MoteStatusEndretRepository.kt
@@ -1,0 +1,60 @@
+package no.nav.syfo.dialogmote.database.repository
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.database.toList
+import no.nav.syfo.dialogmote.api.domain.DialogmoteStatusEndringDTO
+import no.nav.syfo.dialogmote.database.domain.PMoteStatusEndret
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import no.nav.syfo.domain.PersonIdent
+import java.sql.ResultSet
+import java.util.*
+
+class MoteStatusEndretRepository(private val database: DatabaseInterface) {
+
+    fun getMoteStatusEndringer(personident: PersonIdent): List<DialogmoteStatusEndringDTO> =
+        database.connection.use { connection ->
+            connection.prepareStatement(GET_MOTE_STATUS_ENDRINGER).use { ps ->
+                ps.setString(1, personident.value)
+                ps.executeQuery()
+                    .toList {
+                        val pDialogmoteStatusEndret = toPMoteStatusEndret()
+                        DialogmoteStatusEndringDTO(
+                            uuid = pDialogmoteStatusEndret.uuid.toString(),
+                            createdAt = pDialogmoteStatusEndret.createdAt,
+                            dialogmoteId = pDialogmoteStatusEndret.moteId,
+                            dialogmoteOpprettetAv = getString("mote_opprettet_av"),
+                            status = pDialogmoteStatusEndret.status,
+                            statusEndringOpprettetAv = pDialogmoteStatusEndret.opprettetAv,
+                        )
+                    }
+            }
+        }
+
+    companion object {
+        private const val GET_MOTE_STATUS_ENDRINGER =
+            """
+            SELECT
+                mse.*,
+                m.opprettet_av as mote_opprettet_av
+            FROM mote_status_endret mse
+            INNER JOIN mote m on mse.mote_id = m.id
+            INNER JOIN motedeltaker_arbeidstaker mda on m.id = mda.mote_id
+            WHERE mda.personident = ?
+            ORDER BY mse.created_at DESC
+            """
+    }
+}
+
+internal fun ResultSet.toPMoteStatusEndret(): PMoteStatusEndret =
+    PMoteStatusEndret(
+        id = getInt("id"),
+        uuid = UUID.fromString(getString("uuid")),
+        createdAt = getTimestamp("created_at").toLocalDateTime(),
+        updatedAt = getTimestamp("updated_at").toLocalDateTime(),
+        moteId = getInt("mote_id"),
+        motedeltakerBehandler = getBoolean("motedeltaker_behandler"),
+        status = DialogmoteStatus.valueOf(getString("status")),
+        opprettetAv = getString("opprettet_av"),
+        tilfelleStart = getTimestamp("tilfelle_start").toLocalDateTime().toLocalDate(),
+        publishedAt = getTimestamp("published_at")?.toLocalDateTime(),
+    )

--- a/src/test/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerBrevApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/brev/arbeidstaker/ArbeidstakerBrevApiSpek.kt
@@ -27,6 +27,7 @@ import no.nav.syfo.dialogmote.api.v2.dialogmoteApiMoteFerdigstillPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiPersonIdentUrlPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiV2Basepath
 import no.nav.syfo.dialogmote.database.getDialogmote
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.dialogmote.domain.DialogmoteSvarType
 import no.nav.syfo.dialogmote.domain.MotedeltakerVarselType
@@ -105,6 +106,7 @@ class ArbeidstakerBrevApiSpek : Spek({
             )
             val dialogmotestatusService = DialogmotestatusService(
                 oppfolgingstilfelleClient = oppfolgingstilfelleClient,
+                moteStatusEndretRepository = MoteStatusEndretRepository(database),
             )
             val dialogmotedeltakerService = DialogmotedeltakerService(
                 arbeidstakerVarselService = arbeidstakerVarselService,

--- a/src/test/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederBrevSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/brev/narmesteleder/NarmesteLederBrevSpek.kt
@@ -28,6 +28,7 @@ import no.nav.syfo.dialogmote.api.v2.dialogmoteApiMoteFerdigstillPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiPersonIdentUrlPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiV2Basepath
 import no.nav.syfo.dialogmote.database.getDialogmote
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.dialogmote.domain.DialogmoteSvarType
 import no.nav.syfo.dialogmote.domain.MotedeltakerVarselType
@@ -109,6 +110,7 @@ object NarmesteLederBrevSpek : Spek({
             )
             val dialogmotestatusService = DialogmotestatusService(
                 oppfolgingstilfelleClient = oppfolgingstilfelleClient,
+                moteStatusEndretRepository = MoteStatusEndretRepository(database),
             )
             val dialogmotedeltakerService = DialogmotedeltakerService(
                 arbeidstakerVarselService = arbeidstakerVarselService,

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmoteoutdated/DialogmoteOutdatedCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmoteoutdated/DialogmoteOutdatedCronjobSpek.kt
@@ -36,6 +36,7 @@ import no.nav.syfo.dialogmote.DialogmoterelasjonService
 import no.nav.syfo.dialogmote.DialogmotestatusService
 import no.nav.syfo.dialogmote.api.domain.DialogmoteDTO
 import no.nav.syfo.dialogmote.api.v2.*
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.generator.generateAvlysDialogmoteDTO
@@ -92,6 +93,7 @@ class DialogmoteOutdatedCronjobSpek : Spek({
             )
             val dialogmotestatusService = DialogmotestatusService(
                 oppfolgingstilfelleClient = oppfolgingstilfelleClient,
+                moteStatusEndretRepository = MoteStatusEndretRepository(database),
             )
             val arbeidstakerVarselService = ArbeidstakerVarselService(
                 esyfovarselProducer = esyfovarselProducerMock,

--- a/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/motestatusendring/GetDialogmoteStatusEndringApiV2Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/api/v2/motestatusendring/GetDialogmoteStatusEndringApiV2Spek.kt
@@ -1,0 +1,243 @@
+package no.nav.syfo.dialogmote.api.v2.motestatusendring
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.http.*
+import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.server.testing.*
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.client.oppfolgingstilfelle.OppfolgingstilfelleClient
+import no.nav.syfo.dialogmote.DialogmotestatusService
+import no.nav.syfo.dialogmote.api.domain.DialogmoteStatusEndringDTO
+import no.nav.syfo.dialogmote.api.v2.dialogmoteApiV2Basepath
+import no.nav.syfo.dialogmote.database.createNewDialogmoteWithReferences
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
+import no.nav.syfo.dialogmote.domain.DialogmoteStatus
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ANNEN_FNR
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_2
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generateJWTNavIdent
+import no.nav.syfo.testhelper.generator.generateNewDialogmote
+import no.nav.syfo.testhelper.testApiModule
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.bearerHeader
+import no.nav.syfo.util.configuredJacksonMapper
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class GetDialogmoteStatusEndringApiV2Spek : Spek({
+    val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    describe("DialogmoteApiSpek") {
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment.getInstance()
+            val database = externalMockEnvironment.database
+            val dialogmotestatusService = DialogmotestatusService(
+                oppfolgingstilfelleClient = mockk<OppfolgingstilfelleClient>(relaxed = true),
+                moteStatusEndretRepository = MoteStatusEndretRepository(database),
+            )
+
+            application.testApiModule(
+                externalMockEnvironment = externalMockEnvironment,
+            )
+
+            describe("Get motestatusendringer") {
+                val newDialogmote = generateNewDialogmote(ARBEIDSTAKER_FNR)
+                val newDialogmoteFerdigstilt = generateNewDialogmote(
+                    personIdent = ARBEIDSTAKER_FNR,
+                    status = DialogmoteStatus.FERDIGSTILT,
+                )
+
+                afterEachTest {
+                    database.dropData()
+                }
+
+                val validToken = generateJWTNavIdent(
+                    externalMockEnvironment.environment.aadAppClient,
+                    externalMockEnvironment.wellKnownVeilederV2.issuer,
+                    VEILEDER_IDENT,
+                )
+
+                it("returns no content when no mote") {
+                    with(
+                        handleRequest(HttpMethod.Get, "$dialogmoteApiV2Basepath/personident/motestatusendringer") {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.NoContent
+                    }
+                }
+
+                it("returns no content when no mote for given person") {
+                    runBlocking {
+                        database.connection.use { connection ->
+                            val createdDialogmoteIdentifiers = connection.createNewDialogmoteWithReferences(newDialogmote)
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = createdDialogmoteIdentifiers.dialogmoteIdPair.first,
+                                dialogmoteStatus = newDialogmote.status,
+                                opprettetAv = newDialogmote.opprettetAv,
+                            )
+                            connection.commit()
+                        }
+                    }
+
+                    with(
+                        handleRequest(HttpMethod.Get, "$dialogmoteApiV2Basepath/personident/motestatusendringer") {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_ANNEN_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.NoContent
+                    }
+                }
+
+                it("returns motestatusendringer for person") {
+                    runBlocking {
+                        database.connection.use { connection ->
+                            val createdDialogmoteIdentifiers = connection.createNewDialogmoteWithReferences(newDialogmote)
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = createdDialogmoteIdentifiers.dialogmoteIdPair.first,
+                                dialogmoteStatus = newDialogmote.status,
+                                opprettetAv = newDialogmote.opprettetAv,
+                            )
+                            connection.commit()
+                        }
+                    }
+
+                    with(
+                        handleRequest(HttpMethod.Get, "$dialogmoteApiV2Basepath/personident/motestatusendringer") {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val statusendringer = objectMapper.readValue<List<DialogmoteStatusEndringDTO>>(response.content!!)
+                        statusendringer.size shouldBeEqualTo 1
+
+                        statusendringer[0].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                        statusendringer[0].status shouldBeEqualTo DialogmoteStatus.INNKALT
+                        statusendringer[0].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                    }
+                }
+
+                it("returns several motestatusendringer for one mote") {
+                    runBlocking {
+                        database.connection.use { connection ->
+                            val createdDialogmoteIdentifiers = connection.createNewDialogmoteWithReferences(newDialogmote)
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = createdDialogmoteIdentifiers.dialogmoteIdPair.first,
+                                dialogmoteStatus = newDialogmote.status,
+                                opprettetAv = newDialogmote.opprettetAv,
+                            )
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = createdDialogmoteIdentifiers.dialogmoteIdPair.first,
+                                dialogmoteStatus = DialogmoteStatus.NYTT_TID_STED,
+                                opprettetAv = VEILEDER_IDENT_2,
+                            )
+                            connection.commit()
+                        }
+                    }
+
+                    with(
+                        handleRequest(HttpMethod.Get, "$dialogmoteApiV2Basepath/personident/motestatusendringer") {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val statusendringer = objectMapper.readValue<List<DialogmoteStatusEndringDTO>>(response.content!!)
+                        statusendringer.size shouldBeEqualTo 2
+
+                        statusendringer[0].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT_2
+                        statusendringer[0].status shouldBeEqualTo DialogmoteStatus.NYTT_TID_STED
+                        statusendringer[0].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+
+                        statusendringer[1].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                        statusendringer[1].status shouldBeEqualTo DialogmoteStatus.INNKALT
+                        statusendringer[1].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                    }
+                }
+
+                it("returns motestatusendringer for several moter") {
+                    runBlocking {
+                        database.connection.use { connection ->
+                            val moteId1 = connection.createNewDialogmoteWithReferences(newDialogmote)
+                            val moteId2 = connection.createNewDialogmoteWithReferences(newDialogmoteFerdigstilt)
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = moteId1.dialogmoteIdPair.first,
+                                dialogmoteStatus = newDialogmote.status,
+                                opprettetAv = newDialogmote.opprettetAv,
+                            )
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmoteFerdigstilt,
+                                dialogmoteId = moteId2.dialogmoteIdPair.first,
+                                dialogmoteStatus = newDialogmoteFerdigstilt.status,
+                                opprettetAv = newDialogmoteFerdigstilt.opprettetAv,
+                            )
+                            dialogmotestatusService.createMoteStatusEndring(
+                                connection = connection,
+                                newDialogmote = newDialogmote,
+                                dialogmoteId = moteId1.dialogmoteIdPair.first,
+                                dialogmoteStatus = DialogmoteStatus.AVLYST,
+                                opprettetAv = VEILEDER_IDENT_2,
+                            )
+
+                            connection.commit()
+                        }
+                    }
+
+                    with(
+                        handleRequest(HttpMethod.Get, "$dialogmoteApiV2Basepath/personident/motestatusendringer") {
+                            addHeader(Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val statusendringer = objectMapper.readValue<List<DialogmoteStatusEndringDTO>>(response.content!!)
+                        statusendringer.size shouldBeEqualTo 3
+
+                        statusendringer[0].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT_2
+                        statusendringer[0].status shouldBeEqualTo DialogmoteStatus.AVLYST
+                        statusendringer[0].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                        statusendringer[0].dialogmoteId shouldBeEqualTo statusendringer[2].dialogmoteId
+
+                        statusendringer[1].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                        statusendringer[1].status shouldBeEqualTo DialogmoteStatus.FERDIGSTILT
+                        statusendringer[1].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+
+                        statusendringer[2].statusEndringOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                        statusendringer[2].status shouldBeEqualTo DialogmoteStatus.INNKALT
+                        statusendringer[2].dialogmoteOpprettetAv shouldBeEqualTo VEILEDER_IDENT
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/dialogmote/database/repository/MoteRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/database/repository/MoteRepositorySpek.kt
@@ -1,6 +1,7 @@
-package no.nav.syfo.dialogmote.database
+package no.nav.syfo.dialogmote.database.repository
 
 import io.ktor.server.testing.*
+import no.nav.syfo.dialogmote.database.createNewDialogmoteWithReferences
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.dropData

--- a/src/test/kotlin/no/nav/syfo/janitor/JanitorServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/janitor/JanitorServiceSpek.kt
@@ -17,6 +17,7 @@ import no.nav.syfo.dialogmote.api.v2.dialogmoteApiMoteFerdigstillPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiPersonIdentUrlPath
 import no.nav.syfo.dialogmote.api.v2.dialogmoteApiV2Basepath
 import no.nav.syfo.dialogmote.database.getDialogmoteList
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import no.nav.syfo.dialogmote.database.getMoteStatusEndretNotPublished
 import no.nav.syfo.dialogmote.domain.DialogmoteStatus
 import no.nav.syfo.janitor.kafka.*
@@ -56,7 +57,10 @@ class JanitorServiceSpek : Spek({
             val eventStatusProducerMock = mockk<JanitorEventStatusProducer>(relaxed = true)
             justRun { eventStatusProducerMock.sendEventStatus(any()) }
 
-            val dialogmotestatusService = DialogmotestatusService(oppfolgingstilfelleClient = mockk(relaxed = true))
+            val dialogmotestatusService = DialogmotestatusService(
+                oppfolgingstilfelleClient = mockk(relaxed = true),
+                moteStatusEndretRepository = MoteStatusEndretRepository(database),
+            )
             val dialogmotedeltakerService =
                 DialogmotedeltakerService(database = database, arbeidstakerVarselService = mockk())
             val dialogmoterelasjonService = DialogmoterelasjonService(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.client.tokendings.TokendingsClient
 import no.nav.syfo.dialogmote.DialogmotedeltakerService
 import no.nav.syfo.dialogmote.DialogmoterelasjonService
 import no.nav.syfo.dialogmote.DialogmotestatusService
+import no.nav.syfo.dialogmote.database.repository.MoteStatusEndretRepository
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
 import redis.clients.jedis.Protocol
@@ -51,7 +52,10 @@ fun Application.testApiModule(
         isoppfolgingstilfelleBaseUrl = externalMockEnvironment.environment.isoppfolgingstilfelleUrl,
         cache = cache,
     )
-    val dialogmotestatusService = DialogmotestatusService(oppfolgingstilfelleClient = oppfolgingstilfelleClient)
+    val dialogmotestatusService = DialogmotestatusService(
+        oppfolgingstilfelleClient = oppfolgingstilfelleClient,
+        moteStatusEndretRepository = MoteStatusEndretRepository(externalMockEnvironment.database),
+    )
     val arbeidstakerVarselService = ArbeidstakerVarselService(
         esyfovarselProducer = esyfovarselProducer,
     )


### PR DESCRIPTION
Legger til et endepunkt som returnerer en liste med alle statusendringer på dialogmøter for en person, og hvilket møte den endringen tilhørte.

Litt frem og tilbake her om man skal vise tidspunkt og sted for møtet, og hva det evt har blitt endret til og fra. Det kan bli mye logikk for å få til noe vi ikke helt vet om de trenger. Jeg tenkte vi derfor bare kunne starte med dette, så blir formatet i frontend ish:
3. nov | X999999 avlyste et dialogmøte (evt "avlyste dialogmøtet")
2. nov | X999999 endret tid eller sted på dialogmøtet (men sier ikke noe om hva som ble endret til)
28. okt | X999999 kalte inn til dialogmøte 