### PR TITLE
IS-3357: Move dialogmelding-client to infrastructure

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dialogmelding/BehandlerDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dialogmelding/BehandlerDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.client.dialogmelding
+package no.nav.syfo.infrastructure.client.dialogmelding
 
 data class BehandlerDTO(
     val behandlerRef: String,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dialogmelding/DialogmeldingClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dialogmelding/DialogmeldingClient.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.client.dialogmelding
+package no.nav.syfo.infrastructure.client.dialogmelding
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.infrastructure.client.cache.ValkeyStore
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.launchBackgroundTask
 import no.nav.syfo.application.ArbeidstakerVarselService
-import no.nav.syfo.client.dialogmelding.DialogmeldingClient
+import no.nav.syfo.infrastructure.client.dialogmelding.DialogmeldingClient
 import no.nav.syfo.infrastructure.client.azuread.AzureAdV2Client
 import no.nav.syfo.infrastructure.client.pdl.PdlClient
 import no.nav.syfo.infrastructure.cronjob.dialogmoteOutdated.DialogmoteOutdatedCronjob

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/journalforing/DialogmoteVarselJournalforingCronjob.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.infrastructure.cronjob.journalforing
 
 import net.logstash.logback.argument.StructuredArguments
-import no.nav.syfo.client.dialogmelding.DialogmeldingClient
+import no.nav.syfo.infrastructure.client.dialogmelding.DialogmeldingClient
 import no.nav.syfo.domain.dialogmote.toJournalforingRequestArbeidsgiver
 import no.nav.syfo.domain.dialogmote.toJournalforingRequestArbeidstaker
 import no.nav.syfo.domain.dialogmote.toJournalforingRequestBehandler

--- a/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobSpek.kt
@@ -18,7 +18,7 @@ import no.nav.syfo.api.endpoints.dialogmoteApiMoteFerdigstillPath
 import no.nav.syfo.api.endpoints.dialogmoteApiMoteTidStedPath
 import no.nav.syfo.api.endpoints.dialogmoteApiV2Basepath
 import no.nav.syfo.application.BehandlerVarselService
-import no.nav.syfo.client.dialogmelding.DialogmeldingClient
+import no.nav.syfo.infrastructure.client.dialogmelding.DialogmeldingClient
 import no.nav.syfo.domain.dialogmote.DialogmoteStatus
 import no.nav.syfo.domain.dialogmote.Referat
 import no.nav.syfo.domain.dialogmote.toJournalpostTittel

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DialogmeldingMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DialogmeldingMock.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
-import no.nav.syfo.client.dialogmelding.BehandlerDTO
+import no.nav.syfo.infrastructure.client.dialogmelding.BehandlerDTO
 import no.nav.syfo.testhelper.UserConstants
 
 val mockBehandlerDTO = BehandlerDTO(


### PR DESCRIPTION
I siste PR så ble dialogmelding-klienten feilplassert.