### PR TITLE
Check for full tilgang for write operations

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/api/PipelineUtil.kt
@@ -29,3 +29,28 @@ suspend fun RoutingContext.validateVeilederAccess(
         )
     }
 }
+
+suspend fun RoutingContext.validateVeilederFullTilgangAndPersonAccess(
+    dialogmoteTilgangService: DialogmoteTilgangService,
+    personIdentToAccess: PersonIdent,
+    action: String,
+    requestBlock: suspend () -> Unit,
+) {
+    val callId = getCallId()
+
+    val token = getBearerHeader()
+        ?: throw IllegalArgumentException("No Authorization header supplied")
+
+    val hasVeilederAccess = dialogmoteTilgangService.hasFullTilgangAndPersonAccess(
+        callId = callId,
+        personIdentList = listOf(personIdentToAccess),
+        token = token,
+    )
+    if (hasVeilederAccess) {
+        requestBlock()
+    } else {
+        throw ForbiddenAccessVeilederException(
+            action = action,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmoteActionsApiV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmoteActionsApiV2.kt
@@ -13,7 +13,7 @@ import no.nav.syfo.api.authentication.getNAVIdentFromToken
 import no.nav.syfo.api.callIdArgument
 import no.nav.syfo.api.getBearerHeader
 import no.nav.syfo.api.getCallId
-import no.nav.syfo.api.validateVeilederAccess
+import no.nav.syfo.api.validateVeilederFullTilgangAndPersonAccess
 import no.nav.syfo.application.DialogmoteService
 import no.nav.syfo.application.DialogmoteTilgangService
 import org.slf4j.Logger
@@ -47,7 +47,7 @@ fun Route.registerDialogmoteActionsApiV2(
 
             val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = dialogmote.arbeidstaker.personIdent,
                 action = "Avlys Dialogmote for moteUUID"
@@ -71,7 +71,7 @@ fun Route.registerDialogmoteActionsApiV2(
 
             val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = dialogmote.arbeidstaker.personIdent,
                 action = "Mellomlagre Dialogmote for moteUUID"
@@ -96,7 +96,7 @@ fun Route.registerDialogmoteActionsApiV2(
 
             val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = dialogmote.arbeidstaker.personIdent,
                 action = "Ferdigstill Dialogmote for moteUUID"
@@ -123,7 +123,7 @@ fun Route.registerDialogmoteActionsApiV2(
 
             val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = dialogmote.arbeidstaker.personIdent,
                 action = "Endre Ferdigstilt Dialogmote for moteUUID"
@@ -151,7 +151,7 @@ fun Route.registerDialogmoteActionsApiV2(
 
             val dialogmote = dialogmoteService.getDialogmote(moteUUID)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = dialogmote.arbeidstaker.personIdent,
                 action = "Create NewDialogmoteTidSted for moteUUID"
@@ -166,6 +166,7 @@ fun Route.registerDialogmoteActionsApiV2(
             }
         }
 
+        // TODO
         post(dialogmoteActionsApiOvertaPath) {
             val callId = getCallId()
             try {
@@ -197,6 +198,7 @@ fun Route.registerDialogmoteActionsApiV2(
             }
         }
 
+        // TODO
         patch(dialogmoteTildelPath) {
             val callId = getCallId()
             try {

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmoteApiV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmoteApiV2.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.api.getBearerHeader
 import no.nav.syfo.api.getCallId
 import no.nav.syfo.api.getPersonIdentHeader
 import no.nav.syfo.api.validateVeilederAccess
+import no.nav.syfo.api.validateVeilederFullTilgangAndPersonAccess
 import no.nav.syfo.application.DialogmoteTilgangService
 import no.nav.syfo.domain.PersonIdent
 
@@ -76,7 +77,7 @@ fun Route.registerDialogmoteApiV2(
 
             val personIdent = PersonIdent(newDialogmoteDTO.arbeidstaker.personIdent)
 
-            validateVeilederAccess(
+            validateVeilederFullTilgangAndPersonAccess(
                 dialogmoteTilgangService = dialogmoteTilgangService,
                 personIdentToAccess = personIdent,
                 action = "Create new Dialogmoteinnkalling"

--- a/src/main/kotlin/no/nav/syfo/application/DialogmoteTilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmoteTilgangService.kt
@@ -1,11 +1,36 @@
 package no.nav.syfo.application
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
 
 class DialogmoteTilgangService(
     private val veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
 ) {
+    suspend fun hasFullTilgangAndPersonAccess(
+        personIdentList: List<PersonIdent>,
+        token: String,
+        callId: String,
+    ): Boolean = coroutineScope {
+        val hasFullTilgang = async {
+            veilederTilgangskontrollClient.hasSyfoFullTilgang(
+                token = token,
+                callId = callId,
+            )
+        }
+
+        val hasAccessToAllPersons = async {
+            hasAccessToAllDialogmotePersons(
+                personIdentList = personIdentList,
+                token = token,
+                callId = callId,
+            )
+        }
+
+        hasFullTilgang.await() && hasAccessToAllPersons.await()
+    }
+
     suspend fun hasAccessToAllDialogmotePersons(
         personIdentList: List<PersonIdent>,
         token: String,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
@@ -2,4 +2,8 @@ package no.nav.syfo.infrastructure.client.veiledertilgang
 
 data class Tilgang(
     val erGodkjent: Boolean,
+    val erAvslatt: Boolean,
+    val fullTilgang: Boolean,
+    val finnfastlegeTilgang: Boolean,
+    val legacyTilgang: Boolean,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -26,12 +26,57 @@ class VeilederTilgangskontrollClient(
     private val httpClient: HttpClient = httpClientDefault(),
 ) {
 
+    private val tilgangskontrollSyfoPermissionsUrl: String
     private val tilgangskontrollPersonListUrl: String
     private val tilgangskontrollEnhetUrl: String
 
     init {
+        tilgangskontrollSyfoPermissionsUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_SYFO_PERMISSIONS_PATH"
         tilgangskontrollPersonListUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_PERSON_LIST_PATH"
         tilgangskontrollEnhetUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_ENHET_PATH"
+    }
+
+    suspend fun hasSyfoFullTilgang(
+        token: String,
+        callId: String,
+    ): Boolean {
+        val oboToken = azureAdV2Client.getOnBehalfOfToken(
+            scopeClientId = tilgangskontrollClientId,
+            token = token
+        )?.accessToken ?: throw RuntimeException("Failed to retrieve syfo-tilganger: Failed to get OBO token")
+
+        val startTime = System.currentTimeMillis()
+        return try {
+            val response: HttpResponse = httpClient.get(urlString = tilgangskontrollSyfoPermissionsUrl) {
+                header(HttpHeaders.Authorization, bearerHeader(token = oboToken))
+                header(NAV_CALL_ID_HEADER, value = callId)
+                accept(ContentType.Application.Json)
+            }
+            if (response.body<Tilgang>().fullTilgang) {
+                COUNT_CALL_TILGANGSKONTROLL_FULL_TILGANG_TRUE.increment()
+                true
+            } else {
+                COUNT_CALL_TILGANGSKONTROLL_FULL_TILGANG_FALSE.increment()
+                false
+            }
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Forbidden) {
+                COUNT_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FORBIDDEN.increment()
+            } else {
+                handleUnexpectedResponseException(e.response, resourceSyfoTilganger, callId)
+            }
+            false
+        } catch (e: ServerResponseException) {
+            COUNT_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FAIL.increment()
+            handleUnexpectedResponseException(e.response, resourceSyfoTilganger, callId)
+            false
+        } catch (e: ClosedReceiveChannelException) {
+            handleClosedReceiveChannelException(e, "hasSyfoFullTilgang", resourceSyfoTilganger)
+            false
+        } finally {
+            val duration = Duration.ofMillis(System.currentTimeMillis() - startTime)
+            HISTOGRAM_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_TIMER.record(duration)
+        }
     }
 
     suspend fun hasAccessToPersonList(
@@ -44,7 +89,7 @@ class VeilederTilgangskontrollClient(
             token = token
         )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 
-        val starttime = System.currentTimeMillis()
+        val startTime = System.currentTimeMillis()
         return try {
             val personIdentStringList = personIdentList.map { it.value }
 
@@ -71,7 +116,7 @@ class VeilederTilgangskontrollClient(
             handleClosedReceiveChannelException(e, "hasAccessToPersonList", resourcePersonList)
             emptyList()
         } finally {
-            val duration = Duration.ofMillis(System.currentTimeMillis() - starttime)
+            val duration = Duration.ofMillis(System.currentTimeMillis() - startTime)
             HISTOGRAM_CALL_TILGANGSKONTROLL_PERSONS_TIMER.record(duration)
         }
     }
@@ -87,7 +132,7 @@ class VeilederTilgangskontrollClient(
         )?.accessToken ?: throw RuntimeException("Failed to request access to Enhet: Failed to get OBO token")
 
         val url = "$tilgangskontrollEnhetUrl/${enhetNr.value}"
-        val starttime = System.currentTimeMillis()
+        val startTime = System.currentTimeMillis()
         return try {
             val response: HttpResponse = httpClient.get(url) {
                 header(HttpHeaders.Authorization, bearerHeader(oboToken))
@@ -111,7 +156,7 @@ class VeilederTilgangskontrollClient(
             handleClosedReceiveChannelException(e, "hasAccessToEnhet", resourceEnhet)
             false
         } finally {
-            val duration = Duration.ofMillis(System.currentTimeMillis() - starttime)
+            val duration = Duration.ofMillis(System.currentTimeMillis() - startTime)
             HISTOGRAM_CALL_TILGANGSKONTROLL_ENHET_TIMER.record(duration)
         }
     }
@@ -153,10 +198,12 @@ class VeilederTilgangskontrollClient(
     companion object {
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
+        private const val resourceSyfoTilganger = "SYFO_TILGANGER"
         private const val resourcePersonList = "PERSONLIST"
         private const val resourceEnhet = "ENHET"
 
         const val TILGANGSKONTROLL_COMMON_PATH = "/api/tilgang/navident"
+        const val TILGANGSKONTROLL_SYFO_PERMISSIONS_PATH = "$TILGANGSKONTROLL_COMMON_PATH/syfo"
         const val TILGANGSKONTROLL_PERSON_LIST_PATH = "$TILGANGSKONTROLL_COMMON_PATH/brukere"
         const val TILGANGSKONTROLL_ENHET_PATH = "$TILGANGSKONTROLL_COMMON_PATH/enhet"
     }

--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -17,6 +17,16 @@ const val CALL_TILGANGSKONTROLL_ENHET_SUCCESS = "${CALL_TILGANGSKONTROLL_ENHET_B
 const val CALL_TILGANGSKONTROLL_ENHET_FAIL = "${CALL_TILGANGSKONTROLL_ENHET_BASE}_fail_count"
 const val CALL_TILGANGSKONTROLL_ENHET_FORBIDDEN = "${CALL_TILGANGSKONTROLL_ENHET_BASE}_forbidden_count"
 
+const val CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE = "${METRICS_NS}_call_tilgangskontroll_syfo_tilgnanger"
+const val CALL_TILGANGSKONTROLL_FULL_TILGANG_TRUE = "${CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE}_" +
+        "full_tilgang_true_count"
+const val CALL_TILGANGSKONTROLL_FULL_TILGANG_FALSE = "${CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE}_" +
+        "full_tilgang_false_count"
+const val CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FAIL = "${CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE}_fail_count"
+const val CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FORBIDDEN = "${CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE}_" +
+        "forbidden_count"
+const val CALL_TILGANGSKONTROLL_SYFO_TILGANGER_TIMER = "${CALL_TILGANGSKONTROLL_SYFO_TILGANGER_BASE}_timer"
+
 const val CALL_PDL_SUCCESS = "${METRICS_NS}_call_pdl_success_count"
 const val CALL_PDL_FAIL = "${METRICS_NS}_call_pdl_fail_count"
 
@@ -45,6 +55,20 @@ val COUNT_CALL_TILGANGSKONTROLL_ENHET_FAIL: Counter = Counter.builder(CALL_TILGA
 val COUNT_CALL_TILGANGSKONTROLL_ENHET_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_ENHET_FORBIDDEN)
     .description("Counts the number of forbidden calls to istilgangskontroll - enhet")
     .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_FULL_TILGANG_TRUE: Counter = Counter.builder(CALL_TILGANGSKONTROLL_FULL_TILGANG_TRUE)
+    .description("Counts the number of calls to istilgangskontroll - tilganger returning fullTilgang true")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_FULL_TILGANG_FALSE: Counter = Counter.builder(CALL_TILGANGSKONTROLL_FULL_TILGANG_FALSE)
+    .description("Counts the number of calls to istilgangskontroll - tilganger returning fullTilgang false")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FAIL: Counter = Counter.builder(
+    CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FAIL)
+    .description("Counts the number of failed write access calls to istilgangskontroll")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FORBIDDEN: Counter = Counter.builder(
+    CALL_TILGANGSKONTROLL_SYFO_TILGANGER_FORBIDDEN)
+    .description("Counts the number of forbidden write access calls to istilgangskontroll")
+    .register(METRICS_REGISTRY)
 val COUNT_CALL_PDL_SUCCESS: Counter = Counter.builder(CALL_PDL_SUCCESS)
     .description("Counts the number of successful calls to pdl")
     .register(METRICS_REGISTRY)
@@ -71,6 +95,10 @@ val HISTOGRAM_CALL_TILGANGSKONTROLL_ENHET_TIMER: Timer = Timer
 val HISTOGRAM_CALL_TILGANGSKONTROLL_PERSONS_TIMER: Timer = Timer
     .builder(CALL_TILGANGSKONTROLL_PERSONS_TIMER)
     .description("Timer for calls to tilgangskontroll persons")
+    .register(METRICS_REGISTRY)
+val HISTOGRAM_CALL_TILGANGSKONTROLL_SYFO_TILGANGER_TIMER: Timer = Timer
+    .builder(CALL_TILGANGSKONTROLL_SYFO_TILGANGER_TIMER)
+    .description("Timer for write access calls to tilgangskontroll")
     .register(METRICS_REGISTRY)
 val HISTOGRAM_CALL_DIALOGMOTER_ENHET_TIMER: Timer = Timer
     .builder(CALL_DIALOGMOTER_ENHET_TIMER)


### PR DESCRIPTION
Tidlig WIP implementasjon for å diskutere fremgangsmåte.

Hovedpoenget her er en ny "PipelineUtil" funsksjon som både sjekker tilgang til personer som før og også sjekker full tilgang. Det blir da gjort to nettverkskall i parallell til `istilgangskontroll` for å sjekke disse to tingene.

Litt usikker på om `hasSyfoFullTilgang` i `VeilederTilgangskontrollClient.kt` burde sjekke om `fullTilgang` er true som her eller sende objektet med hvilke tilganger brukeren har videre.
Usikker på hvor funksjonen som gjør de to tingene i parallell bør ligge.
Det ble en del "duplisert" try-catch kode med sjekkene mot ulike exceptions i `VeilederTilgangKontrollClient.kt` i `hasSyfoFullTilgang`, men det tror jeg er vanskelig å unngå.