### PR TITLE
chore: remove esyfo-proxy inbound access

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -67,9 +67,6 @@ spec:
         - application: dialogmote-frontend
           namespace: team-esyfo
           cluster: dev-gcp
-        - application: esyfo-proxy
-          namespace: team-esyfo
-          cluster: dev-gcp
         - application: dialogmote-microfrontend
           namespace: team-esyfo
           cluster: dev-gcp

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -67,9 +67,6 @@ spec:
         - application: dialogmote-frontend
           namespace: team-esyfo
           cluster: prod-gcp
-        - application: esyfo-proxy
-          namespace: team-esyfo
-          cluster: prod-gcp
         - application: dialogmote-microfrontend
           namespace: team-esyfo
           cluster: prod-gcp


### PR DESCRIPTION
## Summary
- remove the `esyfo-proxy` inbound access rule from dev NAIS config
- remove the `esyfo-proxy` inbound access rule from prod NAIS config
- align `isdialogmote` with the esyfo-proxy shutdown follow-up

Closes navikt/esyfo-proxy#794