### PR TITLE
Utsett deaktivering av sending til Altinn2

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VarselService.kt
@@ -72,10 +72,10 @@ class VarselService(
         if (isAltinnSendingEnabled && LocalDateTime.now().isBefore(
                 LocalDateTime.of(
                         /* year = */ 2026,
-                        /* month = */ 5,
-                        /* dayOfMonth = */ 29,
-                        /* hour = */ 23,
-                        /* minute = */59
+                        /* month = */ 6,
+                        /* dayOfMonth = */ 15,
+                        /* hour = */ 11,
+                        /* minute = */45
                     )
             )
         ) {


### PR DESCRIPTION
Det er besluttet at tidspunkt for når man ikke lenger kan hente dokumenter om dialogmøter på Altinn2, settet til 15 juni kl 12. 

Dermed utsetter vi avslutningen av sending til Altinn2 til 15 minutter før dette tidspunktet.