### PR TITLE
feat(dokumentporten): legg til varselinstruks

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -34,6 +34,7 @@ import no.nav.syfo.infrastructure.client.altinn.createPort
 import no.nav.syfo.infrastructure.client.dokumentporten.DokumentportenClient
 import no.nav.syfo.infrastructure.client.azuread.AzureAdV2Client
 import no.nav.syfo.infrastructure.client.behandlendeenhet.BehandlendeEnhetClient
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 import no.nav.syfo.infrastructure.client.motebehov.MotebehovClient
 import no.nav.syfo.infrastructure.client.narmesteleder.NarmesteLederClient
 import no.nav.syfo.infrastructure.client.oppfolgingstilfelle.OppfolgingstilfelleClient
@@ -151,6 +152,9 @@ fun main() {
         syfomotebehovClientId = environment.syfomotebehovClientId,
         syfomotebehovBaseUrl = environment.syfomotebehovUrl,
     )
+    val eregClient = EregClient(
+        baseUrl = environment.eregUrl,
+    )
 
     lateinit var behandlerVarselService: BehandlerVarselService
     lateinit var dialogmotestatusService: DialogmotestatusService
@@ -216,6 +220,7 @@ fun main() {
                 narmesteLederClient = narmesteLederClient,
                 dokumentportenClient = dokumentportenClient,
                 motebehovClient = motebehovClient,
+                eregClient = eregClient,
                 pdfRepository = pdfRepository,
                 moteRepository = moteRepository,
                 transactionManager = transactionManager,

--- a/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
@@ -40,6 +40,7 @@ import no.nav.syfo.application.VarselService
 import no.nav.syfo.infrastructure.client.altinn.AltinnClient
 import no.nav.syfo.infrastructure.client.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.infrastructure.client.dokumentporten.DokumentportenClient
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 import no.nav.syfo.infrastructure.client.motebehov.MotebehovClient
 import no.nav.syfo.infrastructure.client.narmesteleder.NarmesteLederClient
 import no.nav.syfo.infrastructure.client.oppfolgingstilfelle.OppfolgingstilfelleClient
@@ -72,6 +73,7 @@ fun Application.apiModule(
     narmesteLederClient: NarmesteLederClient,
     dokumentportenClient: DokumentportenClient,
     motebehovClient: MotebehovClient,
+    eregClient: EregClient,
     pdfRepository: IPdfRepository,
     moteRepository: IMoteRepository,
     transactionManager: ITransactionManager,
@@ -117,7 +119,8 @@ fun Application.apiModule(
         dokumentportenClient = dokumentportenClient,
         oppfolgingstilfelleClient = oppfolgingstilfelleClient,
         isAltinnSendingEnabled = environment.altinnSendingEnabled,
-        isDokumentportenSendingEnabled = environment.dokumentportenSendingEnabled
+        isDokumentportenSendingEnabled = environment.dokumentportenSendingEnabled,
+        eregClient = eregClient,
     )
 
     val avventRepository = AvventRepository(database)

--- a/src/main/kotlin/no/nav/syfo/application/DialogmoteService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmoteService.kt
@@ -616,7 +616,6 @@ class DialogmoteService(
             dialogmotedeltakerService.slettBrukeroppgaverPaMote(
                 dialogmote = dialogmote
             )
-
             varselService.sendVarsel(
                 varselType = MotedeltakerVarselType.REFERAT,
                 isDigitalVarselEnabledForArbeidstaker = digitalVarsling,

--- a/src/main/kotlin/no/nav/syfo/application/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VarselService.kt
@@ -95,6 +95,7 @@ class VarselService(
                     varseltype = varselType,
                     arbeidstakerPersonIdent = arbeidstakerPersonIdent,
                     arbeidstakernavn = arbeidstakernavn,
+                    manglerNarmesteLeder = narmesteLeder == null
                 ),
                 token = token,
                 callId = callId,

--- a/src/main/kotlin/no/nav/syfo/application/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VarselService.kt
@@ -53,16 +53,6 @@ class VarselService(
         token: String,
         callId: String,
     ) {
-        val altinnMelding = createAltinnMelding(
-            virksomhetsbrevId,
-            virksomhetsnummer,
-            virksomhetsPdf,
-            varselType,
-            arbeidstakerPersonIdent,
-            arbeidstakernavn,
-            narmesteLeder != null,
-        )
-
         val tilfelle = oppfolgingstilfelleClient.oppfolgingstilfellePerson(
             callId = callId,
             personIdent = arbeidstakerPersonIdent,
@@ -81,6 +71,15 @@ class VarselService(
                     )
             )
         ) {
+            val altinnMelding = createAltinnMelding(
+                virksomhetsbrevId,
+                virksomhetsnummer,
+                virksomhetsPdf,
+                varselType,
+                arbeidstakerPersonIdent,
+                arbeidstakernavn,
+                narmesteLeder != null,
+            )
             altinnClient.sendToVirksomhet(
                 altinnMelding = altinnMelding,
             )

--- a/src/main/kotlin/no/nav/syfo/application/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VarselService.kt
@@ -16,6 +16,7 @@ import java.time.LocalDateTime
 import java.util.*
 import no.nav.syfo.infrastructure.client.dokumentporten.DokumentportenClient
 import no.nav.syfo.infrastructure.client.dokumentporten.DokumentportenDocumentRequestDTO
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 
 class VarselService(
     private val arbeidstakerVarselService: ArbeidstakerVarselService,
@@ -26,6 +27,7 @@ class VarselService(
     private val oppfolgingstilfelleClient: OppfolgingstilfelleClient,
     private val isAltinnSendingEnabled: Boolean,
     private val isDokumentportenSendingEnabled: Boolean,
+    private val eregClient: EregClient,
 ) {
     private val log: Logger = LoggerFactory.getLogger(VarselService::class.java)
 
@@ -86,16 +88,20 @@ class VarselService(
 
         if (isDokumentportenSendingEnabled) {
             log.info("Dokumentporten utsending er aktiv. Starter utsending av $varselType")
+            val manglerNarmesteLeder = narmesteLeder == null
+            val virksomhetsnavn =
+                if (manglerNarmesteLeder) eregClient.organisasjonVirksomhetsnavn(virksomhetsnummer) else null
 
             dokumentportenClient.sendDocument(
                 DokumentportenDocumentRequestDTO.create(
                     reference = virksomhetsbrevId,
                     virksomhetsnummer = virksomhetsnummer,
+                    virksomhetsnavn = virksomhetsnavn,
                     file = virksomhetsPdf,
                     varseltype = varselType,
                     arbeidstakerPersonIdent = arbeidstakerPersonIdent,
                     arbeidstakernavn = arbeidstakernavn,
-                    manglerNarmesteLeder = narmesteLeder == null
+                    manglerNarmesteLeder = manglerNarmesteLeder,
                 ),
                 token = token,
                 callId = callId,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/DokumentportenDocumentRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/DokumentportenDocumentRequestDTO.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
+import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
 data class DokumentportenDocumentRequestDTO(
     val documentId: UUID,
@@ -62,6 +63,7 @@ data class DokumentportenDocumentRequestDTO(
         fun create(
             reference: UUID,
             virksomhetsnummer: Virksomhetsnummer,
+            virksomhetsnavn: EregVirksomhetsnavn?,
             file: ByteArray,
             varseltype: MotedeltakerVarselType,
             arbeidstakerPersonIdent: PersonIdent,
@@ -78,7 +80,11 @@ data class DokumentportenDocumentRequestDTO(
                 summary = summary(varseltype, arbeidstakernavn),
                 fnr = arbeidstakerPersonIdent.value,
                 fullName = arbeidstakernavn,
-                varselInstruks = if (manglerNarmesteLeder) VarselInstruks.opprettForVarselType(varseltype) else null
+                varselInstruks = if (manglerNarmesteLeder) VarselInstruks.opprettForVarselType(
+                    varselType = varseltype,
+                    virksomhetsnummer = virksomhetsnummer,
+                    virksomhetsnavn = virksomhetsnavn,
+                ) else null
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/DokumentportenDocumentRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/DokumentportenDocumentRequestDTO.kt
@@ -16,6 +16,7 @@ data class DokumentportenDocumentRequestDTO(
     val summary: String,
     val fnr: String,
     val fullName: String,
+    val varselInstruks: VarselInstruks? = null,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -65,6 +66,7 @@ data class DokumentportenDocumentRequestDTO(
             varseltype: MotedeltakerVarselType,
             arbeidstakerPersonIdent: PersonIdent,
             arbeidstakernavn: String,
+            manglerNarmesteLeder: Boolean,
         ): DokumentportenDocumentRequestDTO {
             return DokumentportenDocumentRequestDTO(
                 documentId = reference,
@@ -76,6 +78,7 @@ data class DokumentportenDocumentRequestDTO(
                 summary = summary(varseltype, arbeidstakernavn),
                 fnr = arbeidstakerPersonIdent.value,
                 fullName = arbeidstakernavn,
+                varselInstruks = if (manglerNarmesteLeder) VarselInstruks.opprettForVarselType(varseltype) else null
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -5,79 +5,98 @@ import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
 import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
-private const val EMAIL_TITTEL_INNKALT = "Ny innkalling til dialogmøte i Altinn"
-private const val EMAIL_TITTEL_NYTT_TID_STED = "Ny endring av dialogmøte i Altinn"
-private const val EMAIL_TITTEL_AVLYST = "Ny avlysning av dialogmøte i Altinn"
-private const val EMAIL_TITTEL_REFERAT = "Nytt referat fra dialogmøte i Altinn"
-private const val SIGNATUR = "Vennlig hilsen NAV"
+private const val VARSEL_TEKST_INNKALT = "Innkalling til dialogmøte med Nav"
+private const val VARSEL_TEKST_AVLYST = "Dialogmøte med Nav er avlyst"
+private const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Dialogmøte med Nav er endret"
+private const val VARSEL_TEKST_REFERAT = "Referat fra dialogmøte med Nav"
+
+private const val EMAIL_TITTEL_INNKALT = "Innkalling til dialogmøte med Nav"
+private const val EMAIL_TITTEL_NYTT_TID_STED = "Dialogmøte med Nav er endret"
+private const val EMAIL_TITTEL_AVLYST = "Dialogmøte med Nav er avlyst"
+private const val EMAIL_TITTEL_REFERAT = "Referat fra dialogmøte med Nav"
+private const val SIGNATUR = "Vennlig hilsen Nav"
 
 private const val MOTTAKER_PLACEHOLDER = "{mottaker}"
 
 private val EMAIL_BODY_INNKALT = """
-    <p>{mottaker} er innkalt til dialogmøte med NAV i forbindelse med
+    <p>{mottaker} er innkalt til dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
-    <p>Logg inn i Altinn for å lese innkallingen.</p>
+    <p>Du kan lese innkallingen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
 
     <p>$SIGNATUR</p>
 """
 
 private val EMAIL_BODY_NYTT_TID_STED = """
-    <p>{mottaker} er innkalt til dialogmøte med NAV i  forbindelse med
+    <p>{mottaker} er innkalt til dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
-    <p>NAV har endret tidspunktet eller stedet for dialogmøtet.</p>
+    <p>Nav har endret tidspunktet eller stedet for dialogmøtet.</p>
 
-    <p>Logg inn i Altinn for å lese endringen.</p>
+    <p>Du kan lese endringen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
 
     <p>$SIGNATUR</p>
 """
 
 private val EMAIL_BODY_AVLYST = """
-    <p>{mottaker} var kalt inn til et dialogmøte med NAV i forbindelse med
-    sykefraværet til en  av deres ansatte.</p>
+    <p>{mottaker} var kalt inn til et dialogmøte med Nav i forbindelse med
+    sykefraværet til en av deres ansatte.</p>
 
-    <p>Dette har blitt avlyst.</p>
+    <p>Dialogmøtet har blitt avlyst.</p>
 
-    <p>Logg inn i Altinn for å lese avlysningen.</p>
+    <p> Du kan lese avlysningen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
 
     <p>$SIGNATUR</p>
 """
 
 private val EMAIL_BODY_REFERAT = """
-    <p>{mottaker} har vært i dialogmøte med NAV i forbindelse med
+    <p>{mottaker} har vært i dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
-    <p>Logg inn i Altinn for å lese referatet.</p>
+    <p> Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
 
     <p>$SIGNATUR</p>
 """
 
-private val SMS_BODY_INNKALT =
-    """
-    {mottaker} er innkalt til dialogmøte med NAV i forbindelse med
-    sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese innkallingen. 
-    """.trimIndent()
+private val SMS_BODY_INNKALT = """
+    {mottaker} er innkalt til dialogmøte med Nav i forbindelse med
+    sykefraværet til en av deres ansatte.
 
-private val SMS_BODY_NYTT_TID_STED =
-    """
-    {mottaker} er innkalt til dialogmøte med NAV i forbindelse med
-    sykefraværet til en av deres ansatte. NAV har endret tidspunktet eller stedet for dialogmøtet.
-    Logg inn i Altinn for å lese endringen. 
-    """.trimIndent()
+    Du kan lese innkallingen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
 
-private val SMS_BODY_AVLYST =
-    """
-    {mottaker} var kalt inn til et dialogmøte med NAV i forbindelse med 
-    sykefraværet til en av deres ansatte. Dette har blitt avlyst. Logg inn i Altinn for å lese
-    avlysningen. 
-    """.trimIndent()
+    $SIGNATUR
+""".trimIndent()
 
-private val SMS_BODY_REFERAT =
-    """
-    {mottaker} har vært i dialogmøte med NAV i forbindelse med
-    sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese referatet. 
-    """.trimIndent()
+private val SMS_BODY_NYTT_TID_STED = """
+    {mottaker} er innkalt til dialogmøte med Nav i forbindelse med
+    sykefraværet til en av deres ansatte.
+
+    Nav har endret tidspunktet eller stedet for dialogmøtet.
+
+    Du kan lese endringen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
+
+    $SIGNATUR
+""".trimIndent()
+
+private val SMS_BODY_AVLYST = """
+    {mottaker} var kalt inn til et dialogmøte med Nav i forbindelse med
+    sykefraværet til en av deres ansatte.
+
+    Dialogmøtet har blitt avlyst.
+
+     Du kan lese avlysningen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
+
+    $SIGNATUR
+""".trimIndent()
+
+private val SMS_BODY_REFERAT = """
+    {mottaker} har vært i dialogmøte med Nav i forbindelse med
+    sykefraværet til en av deres ansatte.
+
+     Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
+
+    $SIGNATUR
+""".trimIndent()
 
 private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
     return when (varseltype) {
@@ -85,6 +104,15 @@ private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
         MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
         MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
+    }
+}
+
+private fun toVarselTekst(varseltype: MotedeltakerVarselType): String {
+    return when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> VARSEL_TEKST_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> VARSEL_TEKST_AVLYST
+        MotedeltakerVarselType.REFERAT -> VARSEL_TEKST_REFERAT
     }
 }
 
@@ -121,7 +149,13 @@ private fun toSMSBody(
 ): String {
     val template = when (varseltype) {
         MotedeltakerVarselType.INNKALT -> SMS_BODY_INNKALT
-        MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED.withMottaker(toMottaker(virksomhetsnummer, virksomhetsnavn))
+        MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED.withMottaker(
+            toMottaker(
+                virksomhetsnummer,
+                virksomhetsnavn
+            )
+        )
+
         MotedeltakerVarselType.AVLYST -> SMS_BODY_AVLYST
         MotedeltakerVarselType.REFERAT -> SMS_BODY_REFERAT
     }
@@ -145,6 +179,7 @@ data class VarselInstruks(
                     epostTittel = toEmailTitle(varselType),
                     epostBody = toEmailBody(varselType, virksomhetsnummer, virksomhetsnavn),
                     smsTekst = toSMSBody(varselType, virksomhetsnummer, virksomhetsnavn),
+                    varselTekst = toVarselTekst(varselType)
                 ),
                 kilde = "DIALOGMOTE"
             )
@@ -156,6 +191,7 @@ data class NotifikasjonInnhold(
     val epostTittel: String,
     val epostBody: String,
     val smsTekst: String,
+    val varselTekst: String,
 )
 
 enum class HendelseType {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -1,0 +1,130 @@
+package no.nav.syfo.infrastructure.client.dokumentporten
+
+import kotlin.String
+import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
+
+private const val EMAIL_TITTEL_INNKALT = "Ny innkalling til dialogmøte i Altinn"
+private const val EMAIL_TITTEL_NYTT_TID_STED = "Ny endring av dialogmøte i Altinn"
+private const val EMAIL_TITTEL_AVLYST = "Ny avlysning av dialogmøte i Altinn"
+private const val EMAIL_TITTEL_REFERAT = "Nytt referat fra dialogmøte i Altinn"
+private const val SIGNATUR = "Vennlig hilsen NAV"
+
+private const val ALTINN_VAR_REPORTEE_NAME = "\$reporteeName$"
+private const val ALTINN_VAR_REPORTEE_NUMBER = "\$reporteeNumber$"
+
+private const val EMAIL_BODY_INNKALT = """
+    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+    sykefraværet til en av deres ansatte.</p>
+
+    <p>Logg inn i Altinn for å lese innkallingen.</p>
+
+    <p>$SIGNATUR</p>
+"""
+private const val EMAIL_BODY_NYTT_TID_STED = """
+    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i  forbindelse med
+    sykefraværet til en av deres ansatte.</p>
+
+    <p>NAV har endret tidspunktet eller stedet for dialogmøtet.</p>
+
+    <p>Logg inn i Altinn for å lese endringen.</p>
+
+    <p>$SIGNATUR</p>
+"""
+private const val EMAIL_BODY_AVLYST = """
+    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) var kalt inn til et dialogmøte med NAV i forbindelse med
+    sykefraværet til en  av deres ansatte.</p>
+
+    <p>Dette har blitt avlyst.</p>
+
+    <p>Logg inn i Altinn for å lese avlysningen.</p>
+
+    <p>$SIGNATUR</p>
+"""
+private const val EMAIL_BODY_REFERAT = """
+    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) har vært i dialogmøte med NAV i forbindelse med
+    sykefraværet til en av deres ansatte.</p>
+
+    <p>Logg inn i Altinn for å lese referatet.</p>
+
+    <p>$SIGNATUR</p>
+"""
+
+private val SMS_BODY_INNKALT =
+    """
+    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+    sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese innkallingen. 
+    """.trimIndent()
+private val SMS_BODY_NYTT_TID_STED =
+    """
+    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+    sykefraværet til en av deres ansatte. NAV har endret tidspunktet eller stedet for dialogmøtet.
+    Logg inn i Altinn for å lese endringen. 
+    """.trimIndent()
+private var SMS_BODY_AVLYST =
+    """
+    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) var kalt inn til et dialogmøte med NAV i forbindelse med 
+    sykefraværet til en av deres ansatte. Dette har blitt avlyst. Logg inn i Altinn for å lese
+    avlysningen. 
+    """.trimIndent()
+private val SMS_BODY_REFERAT =
+    """
+    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) har vært i dialogmøte med NAV i forbindelse med
+    sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese referatet. 
+    """.trimIndent()
+
+data class VarselInstruks(
+    val type: HendelseType,
+    val notifikasjonInnhold: NotifikasjonInnhold,
+    val kilde: String,
+) {
+    companion object {
+        fun opprettForVarselType(varselType: MotedeltakerVarselType): VarselInstruks {
+            return VarselInstruks(
+                type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
+                notifikasjonInnhold = NotifikasjonInnhold(
+                    epostTittel = toEmailTitle(varselType),
+                    epostBody = toEmailBody(varselType),
+                    smsTekst = toSMSBody(varselType),
+                ),
+                kilde = "DIALOGMOTE"
+            )
+        }
+    }
+}
+
+data class NotifikasjonInnhold(
+    val epostTittel: String,
+    val epostBody: String,
+    val smsTekst: String,
+)
+
+enum class HendelseType {
+    AG_VARSEL_ALTINN_RESSURS,
+}
+
+private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
+    return when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> EMAIL_TITTEL_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
+        MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
+    }
+}
+
+private fun toEmailBody(varseltype: MotedeltakerVarselType): String {
+    return when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> EMAIL_BODY_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_BODY_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> EMAIL_BODY_AVLYST
+        MotedeltakerVarselType.REFERAT -> EMAIL_BODY_REFERAT
+    }
+}
+
+private fun toSMSBody(varseltype: MotedeltakerVarselType): String {
+    return when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> SMS_BODY_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> SMS_BODY_AVLYST
+        MotedeltakerVarselType.REFERAT -> SMS_BODY_REFERAT
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
 import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
+private const val KILDE = "isdialogmote"
 private const val VARSEL_TEKST_INNKALT = "Innkalling til dialogmøte med Nav"
 private const val VARSEL_TEKST_AVLYST = "Dialogmøte med Nav er avlyst"
 private const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Dialogmøte med Nav er endret"
@@ -181,7 +182,7 @@ data class VarselInstruks(
                     smsTekst = toSMSBody(varselType, virksomhetsnummer, virksomhetsnavn),
                     varselTekst = toVarselTekst(varselType)
                 ),
-                kilde = "DIALOGMOTE"
+                kilde = KILDE
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -1,7 +1,9 @@
 package no.nav.syfo.infrastructure.client.dokumentporten
 
 import kotlin.String
+import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
+import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
 private const val EMAIL_TITTEL_INNKALT = "Ny innkalling til dialogmøte i Altinn"
 private const val EMAIL_TITTEL_NYTT_TID_STED = "Ny endring av dialogmøte i Altinn"
@@ -9,19 +11,19 @@ private const val EMAIL_TITTEL_AVLYST = "Ny avlysning av dialogmøte i Altinn"
 private const val EMAIL_TITTEL_REFERAT = "Nytt referat fra dialogmøte i Altinn"
 private const val SIGNATUR = "Vennlig hilsen NAV"
 
-private const val ALTINN_VAR_REPORTEE_NAME = "\$reporteeName$"
-private const val ALTINN_VAR_REPORTEE_NUMBER = "\$reporteeNumber$"
+private const val MOTTAKER_PLACEHOLDER = "{mottaker}"
 
-private const val EMAIL_BODY_INNKALT = """
-    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+private val EMAIL_BODY_INNKALT = """
+    <p>{mottaker} er innkalt til dialogmøte med NAV i forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
     <p>Logg inn i Altinn for å lese innkallingen.</p>
 
     <p>$SIGNATUR</p>
 """
-private const val EMAIL_BODY_NYTT_TID_STED = """
-    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i  forbindelse med
+
+private val EMAIL_BODY_NYTT_TID_STED = """
+    <p>{mottaker} er innkalt til dialogmøte med NAV i  forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
     <p>NAV har endret tidspunktet eller stedet for dialogmøtet.</p>
@@ -30,8 +32,9 @@ private const val EMAIL_BODY_NYTT_TID_STED = """
 
     <p>$SIGNATUR</p>
 """
-private const val EMAIL_BODY_AVLYST = """
-    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) var kalt inn til et dialogmøte med NAV i forbindelse med
+
+private val EMAIL_BODY_AVLYST = """
+    <p>{mottaker} var kalt inn til et dialogmøte med NAV i forbindelse med
     sykefraværet til en  av deres ansatte.</p>
 
     <p>Dette har blitt avlyst.</p>
@@ -40,8 +43,9 @@ private const val EMAIL_BODY_AVLYST = """
 
     <p>$SIGNATUR</p>
 """
-private const val EMAIL_BODY_REFERAT = """
-    <p>$ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) har vært i dialogmøte med NAV i forbindelse med
+
+private val EMAIL_BODY_REFERAT = """
+    <p>{mottaker} har vært i dialogmøte med NAV i forbindelse med
     sykefraværet til en av deres ansatte.</p>
 
     <p>Logg inn i Altinn for å lese referatet.</p>
@@ -51,26 +55,78 @@ private const val EMAIL_BODY_REFERAT = """
 
 private val SMS_BODY_INNKALT =
     """
-    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+    {mottaker} er innkalt til dialogmøte med NAV i forbindelse med
     sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese innkallingen. 
     """.trimIndent()
+
 private val SMS_BODY_NYTT_TID_STED =
     """
-    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) er innkalt til dialogmøte med NAV i forbindelse med
+    {mottaker} er innkalt til dialogmøte med NAV i forbindelse med
     sykefraværet til en av deres ansatte. NAV har endret tidspunktet eller stedet for dialogmøtet.
     Logg inn i Altinn for å lese endringen. 
     """.trimIndent()
-private var SMS_BODY_AVLYST =
+
+private val SMS_BODY_AVLYST =
     """
-    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) var kalt inn til et dialogmøte med NAV i forbindelse med 
+    {mottaker} var kalt inn til et dialogmøte med NAV i forbindelse med 
     sykefraværet til en av deres ansatte. Dette har blitt avlyst. Logg inn i Altinn for å lese
     avlysningen. 
     """.trimIndent()
+
 private val SMS_BODY_REFERAT =
     """
-    $ALTINN_VAR_REPORTEE_NAME ($ALTINN_VAR_REPORTEE_NUMBER) har vært i dialogmøte med NAV i forbindelse med
+    {mottaker} har vært i dialogmøte med NAV i forbindelse med
     sykefraværet til en av deres ansatte. Logg inn i Altinn for å lese referatet. 
     """.trimIndent()
+
+private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
+    return when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> EMAIL_TITTEL_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
+        MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
+    }
+}
+
+private fun toMottaker(
+    virksomhetsnummer: Virksomhetsnummer,
+    virksomhetsnavn: EregVirksomhetsnavn?,
+): String =
+    virksomhetsnavn?.let {
+        "${virksomhetsnavn.virksomhetsnavn} (${virksomhetsnummer.value})"
+    } ?: "Virksomhet med orgnummer ${virksomhetsnummer.value}"
+
+private fun String.withMottaker(mottaker: String): String =
+    replace(MOTTAKER_PLACEHOLDER, mottaker)
+
+private fun toEmailBody(
+    varseltype: MotedeltakerVarselType,
+    virksomhetsnummer: Virksomhetsnummer,
+    virksomhetsnavn: EregVirksomhetsnavn?
+): String {
+    val template = when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> EMAIL_BODY_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_BODY_NYTT_TID_STED
+        MotedeltakerVarselType.AVLYST -> EMAIL_BODY_AVLYST
+        MotedeltakerVarselType.REFERAT -> EMAIL_BODY_REFERAT
+    }
+
+    return template.withMottaker(toMottaker(virksomhetsnummer, virksomhetsnavn))
+}
+
+private fun toSMSBody(
+    varseltype: MotedeltakerVarselType,
+    virksomhetsnummer: Virksomhetsnummer,
+    virksomhetsnavn: EregVirksomhetsnavn?
+): String {
+    val template = when (varseltype) {
+        MotedeltakerVarselType.INNKALT -> SMS_BODY_INNKALT
+        MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED.withMottaker(toMottaker(virksomhetsnummer, virksomhetsnavn))
+        MotedeltakerVarselType.AVLYST -> SMS_BODY_AVLYST
+        MotedeltakerVarselType.REFERAT -> SMS_BODY_REFERAT
+    }
+    return template.withMottaker(toMottaker(virksomhetsnummer, virksomhetsnavn))
+}
 
 data class VarselInstruks(
     val type: HendelseType,
@@ -78,13 +134,17 @@ data class VarselInstruks(
     val kilde: String,
 ) {
     companion object {
-        fun opprettForVarselType(varselType: MotedeltakerVarselType): VarselInstruks {
+        fun opprettForVarselType(
+            varselType: MotedeltakerVarselType,
+            virksomhetsnummer: Virksomhetsnummer,
+            virksomhetsnavn: EregVirksomhetsnavn?,
+        ): VarselInstruks {
             return VarselInstruks(
                 type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
                 notifikasjonInnhold = NotifikasjonInnhold(
                     epostTittel = toEmailTitle(varselType),
-                    epostBody = toEmailBody(varselType),
-                    smsTekst = toSMSBody(varselType),
+                    epostBody = toEmailBody(varselType, virksomhetsnummer, virksomhetsnavn),
+                    smsTekst = toSMSBody(varselType, virksomhetsnummer, virksomhetsnavn),
                 ),
                 kilde = "DIALOGMOTE"
             )
@@ -100,31 +160,4 @@ data class NotifikasjonInnhold(
 
 enum class HendelseType {
     AG_VARSEL_ALTINN_RESSURS,
-}
-
-private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
-    return when (varseltype) {
-        MotedeltakerVarselType.INNKALT -> EMAIL_TITTEL_INNKALT
-        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
-        MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
-        MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
-    }
-}
-
-private fun toEmailBody(varseltype: MotedeltakerVarselType): String {
-    return when (varseltype) {
-        MotedeltakerVarselType.INNKALT -> EMAIL_BODY_INNKALT
-        MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_BODY_NYTT_TID_STED
-        MotedeltakerVarselType.AVLYST -> EMAIL_BODY_AVLYST
-        MotedeltakerVarselType.REFERAT -> EMAIL_BODY_REFERAT
-    }
-}
-
-private fun toSMSBody(varseltype: MotedeltakerVarselType): String {
-    return when (varseltype) {
-        MotedeltakerVarselType.INNKALT -> SMS_BODY_INNKALT
-        MotedeltakerVarselType.NYTT_TID_STED -> SMS_BODY_NYTT_TID_STED
-        MotedeltakerVarselType.AVLYST -> SMS_BODY_AVLYST
-        MotedeltakerVarselType.REFERAT -> SMS_BODY_REFERAT
-    }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -6,60 +6,77 @@ import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
 import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
 private const val KILDE = "isdialogmote"
-private const val VARSEL_TEKST_INNKALT = "Innkalling til dialogmøte med Nav"
-private const val VARSEL_TEKST_AVLYST = "Dialogmøte med Nav er avlyst"
-private const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Dialogmøte med Nav er endret"
+private const val VARSEL_TEKST_INNKALT = "Viktig: Innkalling til dialogmøte med Nav"
+private const val VARSEL_TEKST_AVLYST = "Viktig: Dialogmøte med Nav er avlyst"
+private const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret"
 private const val VARSEL_TEKST_REFERAT = "Referat fra dialogmøte med Nav"
 
-private const val EMAIL_TITTEL_INNKALT = "Innkalling til dialogmøte med Nav"
-private const val EMAIL_TITTEL_NYTT_TID_STED = "Dialogmøte med Nav er endret"
-private const val EMAIL_TITTEL_AVLYST = "Dialogmøte med Nav er avlyst"
-private const val EMAIL_TITTEL_REFERAT = "Referat fra dialogmøte med Nav"
+private const val EMAIL_TITTEL_INNKALT = "Viktig: Innkalling til dialogmøte med Nav - {mottaker}"
+private const val EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret - {mottaker}"
+private const val EMAIL_TITTEL_AVLYST = "Viktig: Dialogmøte med Nav er avlyst - {mottaker}"
+private const val EMAIL_TITTEL_REFERAT = "Referat fra dialogmøte med Nav - {mottaker}"
 private const val SIGNATUR = "Vennlig hilsen Nav"
 
 private const val MOTTAKER_PLACEHOLDER = "{mottaker}"
 
 private val EMAIL_BODY_INNKALT = """
-    <p>{mottaker} er innkalt til dialogmøte med Nav i forbindelse med
-    sykefraværet til en av deres ansatte.</p>
+    <p>Hei,
+    Nav har kalt inn til et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går innkallingen til bedriften.
+    Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
 
-    <p>Du kan lese innkallingen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
+    <p>Hva må du gjøre nå?</p>
+    <ul>
+        <li>Logg deg inn i Altinn eller på Min side arbeidsgiver hos Nav for å lese innkalling.</li>
+        <li>Sørg for at lederen som skal delta i møtet får videresendt innkalling.</li>
+        <li>Vurder å få ditt firma til å registrere nærmeste leder for den sykmeldte</li>
+    </ul>
 
     <p>$SIGNATUR</p>
-"""
-
+""".trimIndent()
 private val EMAIL_BODY_NYTT_TID_STED = """
-    <p>{mottaker} er innkalt til dialogmøte med Nav i forbindelse med
-    sykefraværet til en av deres ansatte.</p>
+    <p>Hei,
+    Nav har flyttet tid eller sted for et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går endringen til bedriften.
+    Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
 
-    <p>Nav har endret tidspunktet eller stedet for dialogmøtet.</p>
-
-    <p>Du kan lese endringen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
+    <p>Hva må du gjøre nå?</p>
+    <ul>
+        <li>Logg deg inn i Altinn eller på Min side arbeidsgiver hos Nav for å lese endringen.</li>
+        <li>Sørg for at lederen som skal delta i møtet får videresendt endringen.</li>
+        <li>Vurder å få ditt firma til å registrere nærmeste leder for den sykmeldte</li>
+    </ul>
 
     <p>$SIGNATUR</p>
-"""
+""".trimIndent()
 
 private val EMAIL_BODY_AVLYST = """
-    <p>{mottaker} var kalt inn til et dialogmøte med Nav i forbindelse med
-    sykefraværet til en av deres ansatte.</p>
+    <p>Hei,
+    Nav har avlyst et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går avlysningen til bedriften.
+    Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
 
-    <p>Dialogmøtet har blitt avlyst.</p>
-
-    <p> Du kan lese avlysningen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
-
+    <p>Hva må du gjøre nå?</p>
+    <ul>
+        <li>Logg deg inn i Altinn eller på Min side arbeidsgiver hos Nav for å lese avlysningen.</li>
+        <li>Sørg for at lederen som skal delta i møtet får videresendt avlysningen.</li>
+        <li>Vurder å få ditt firma til å registrere nærmeste leder for den sykmeldte</li>
+    </ul>
+    
     <p>$SIGNATUR</p>
-"""
+""".trimIndent()
 
 private val EMAIL_BODY_REFERAT = """
-    <p>{mottaker} har vært i dialogmøte med Nav i forbindelse med
-    sykefraværet til en av deres ansatte.</p>
+    <p>Hei,
+    Nav har sendt referat fra et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går referatet til bedriften.
+    Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
+
+    <p>Hva må du gjøre nå?</p>
+    <ul>
+        <li>Logg deg inn i Altinn eller på Min side arbeidsgiver hos Nav for å lese referatet.</li>
+        <li>Sørg for at lederen som skal delta i møtet får videresendt avlysningen.</li>
+        <li>Vurder å få ditt firma til å registrere nærmeste leder for den sykmeldte</li>
+    </ul>
     
-    <p>Referatet er nå tilgjengelig.</p>
-
-    <p>Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
-
     <p>$SIGNATUR</p>
-"""
+""".trimIndent()
 
 private val SMS_BODY_INNKALT = """
     {mottaker} er innkalt til dialogmøte med Nav i forbindelse med
@@ -87,7 +104,7 @@ private val SMS_BODY_AVLYST = """
 
     Dialogmøtet har blitt avlyst.
 
-     Du kan lese avlysningen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
+    Du kan lese avlysningen i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
 
     $SIGNATUR
 """.trimIndent()
@@ -96,30 +113,36 @@ private val SMS_BODY_REFERAT = """
     {mottaker} har vært i dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
     
-     Referatet er nå tilgjengelig.
+    Referatet er nå tilgjengelig.
 
-     Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
+    Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
 
     $SIGNATUR
 """.trimIndent()
 
-private fun toEmailTitle(varseltype: MotedeltakerVarselType): String {
-    return when (varseltype) {
+private fun toEmailTitle(
+    varseltype: MotedeltakerVarselType,
+    virksomhetsnummer: Virksomhetsnummer,
+    virksomhetsnavn: EregVirksomhetsnavn?
+): String {
+    val template = when (varseltype) {
         MotedeltakerVarselType.INNKALT -> EMAIL_TITTEL_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> EMAIL_TITTEL_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> EMAIL_TITTEL_AVLYST
         MotedeltakerVarselType.REFERAT -> EMAIL_TITTEL_REFERAT
     }
+    return template.withMottaker(toMottaker(virksomhetsnummer, virksomhetsnavn))
 }
 
-private fun toVarselTekst(varseltype: MotedeltakerVarselType): String {
-    return when (varseltype) {
+private fun toVarselTekst(
+    varseltype: MotedeltakerVarselType,
+): String =
+    when (varseltype) {
         MotedeltakerVarselType.INNKALT -> VARSEL_TEKST_INNKALT
         MotedeltakerVarselType.NYTT_TID_STED -> VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED
         MotedeltakerVarselType.AVLYST -> VARSEL_TEKST_AVLYST
         MotedeltakerVarselType.REFERAT -> VARSEL_TEKST_REFERAT
     }
-}
 
 private fun toMottaker(
     virksomhetsnummer: Virksomhetsnummer,
@@ -181,7 +204,7 @@ data class VarselInstruks(
             return VarselInstruks(
                 type = HendelseType.AG_VARSEL_ALTINN_RESSURS,
                 notifikasjonInnhold = NotifikasjonInnhold(
-                    epostTittel = toEmailTitle(varselType),
+                    epostTittel = toEmailTitle(varselType, virksomhetsnummer, virksomhetsnavn),
                     epostBody = toEmailBody(varselType, virksomhetsnummer, virksomhetsnavn),
                     smsTekst = toSMSBody(varselType, virksomhetsnummer, virksomhetsnavn),
                     varselTekst = toVarselTekst(varselType)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -6,20 +6,20 @@ import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
 import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 
 private const val KILDE = "isdialogmote"
-private const val VARSEL_TEKST_INNKALT = "Viktig: Innkalling til dialogmøte med Nav"
-private const val VARSEL_TEKST_AVLYST = "Viktig: Dialogmøte med Nav er avlyst"
-private const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret"
-private const val VARSEL_TEKST_REFERAT = "Referat fra dialogmøte med Nav"
+internal const val VARSEL_TEKST_INNKALT = "Viktig: Innkalling til dialogmøte med Nav"
+internal const val VARSEL_TEKST_AVLYST = "Viktig: Dialogmøte med Nav er avlyst"
+internal const val VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret"
+internal const val VARSEL_TEKST_REFERAT = "Referat fra dialogmøte med Nav"
 
-private const val EMAIL_TITTEL_INNKALT = "Viktig: Innkalling til dialogmøte med Nav - {mottaker}"
-private const val EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret - {mottaker}"
-private const val EMAIL_TITTEL_AVLYST = "Viktig: Dialogmøte med Nav er avlyst - {mottaker}"
-private const val EMAIL_TITTEL_REFERAT = "Referat fra dialogmøte med Nav - {mottaker}"
+internal const val EMAIL_TITTEL_INNKALT = "Viktig: Innkalling til dialogmøte med Nav - {mottaker}"
+internal const val EMAIL_TITTEL_NYTT_TID_STED = "Viktig: Dialogmøte med Nav er endret - {mottaker}"
+internal const val EMAIL_TITTEL_AVLYST = "Viktig: Dialogmøte med Nav er avlyst - {mottaker}"
+internal const val EMAIL_TITTEL_REFERAT = "Referat fra dialogmøte med Nav - {mottaker}"
 private const val SIGNATUR = "Vennlig hilsen Nav"
 
 private const val MOTTAKER_PLACEHOLDER = "{mottaker}"
 
-private val EMAIL_BODY_INNKALT = """
+internal val EMAIL_BODY_INNKALT = """
     <p>Hei,
     Nav har kalt inn til et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går innkallingen til bedriften.
     Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
@@ -33,7 +33,7 @@ private val EMAIL_BODY_INNKALT = """
 
     <p>$SIGNATUR</p>
 """.trimIndent()
-private val EMAIL_BODY_NYTT_TID_STED = """
+internal val EMAIL_BODY_NYTT_TID_STED = """
     <p>Hei,
     Nav har flyttet tid eller sted for et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går endringen til bedriften.
     Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
@@ -48,7 +48,7 @@ private val EMAIL_BODY_NYTT_TID_STED = """
     <p>$SIGNATUR</p>
 """.trimIndent()
 
-private val EMAIL_BODY_AVLYST = """
+internal val EMAIL_BODY_AVLYST = """
     <p>Hei,
     Nav har avlyst et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går avlysningen til bedriften.
     Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
@@ -63,7 +63,7 @@ private val EMAIL_BODY_AVLYST = """
     <p>$SIGNATUR</p>
 """.trimIndent()
 
-private val EMAIL_BODY_REFERAT = """
+internal val EMAIL_BODY_REFERAT = """
     <p>Hei,
     Nav har sendt referat fra et dialogmøte for en av deres ansatte. Når nærmeste leder ikke er registrert hos Nav, går referatet til bedriften.
     Du mottar denne beskjeden fordi du er satt opp for å motta varsler om dialogmøter i Altinn for {mottaker}.
@@ -78,7 +78,7 @@ private val EMAIL_BODY_REFERAT = """
     <p>$SIGNATUR</p>
 """.trimIndent()
 
-private val SMS_BODY_INNKALT = """
+internal val SMS_BODY_INNKALT = """
     {mottaker} er innkalt til dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
 
@@ -87,7 +87,7 @@ private val SMS_BODY_INNKALT = """
     $SIGNATUR
 """.trimIndent()
 
-private val SMS_BODY_NYTT_TID_STED = """
+internal val SMS_BODY_NYTT_TID_STED = """
     {mottaker} er innkalt til dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
 
@@ -98,7 +98,7 @@ private val SMS_BODY_NYTT_TID_STED = """
     $SIGNATUR
 """.trimIndent()
 
-private val SMS_BODY_AVLYST = """
+internal val SMS_BODY_AVLYST = """
     {mottaker} var kalt inn til et dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
 
@@ -109,7 +109,7 @@ private val SMS_BODY_AVLYST = """
     $SIGNATUR
 """.trimIndent()
 
-private val SMS_BODY_REFERAT = """
+internal val SMS_BODY_REFERAT = """
     {mottaker} har vært i dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
     

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruks.kt
@@ -53,8 +53,10 @@ private val EMAIL_BODY_AVLYST = """
 private val EMAIL_BODY_REFERAT = """
     <p>{mottaker} har vært i dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.</p>
+    
+    <p>Referatet er nå tilgjengelig.</p>
 
-    <p> Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
+    <p>Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.</p>
 
     <p>$SIGNATUR</p>
 """
@@ -93,6 +95,8 @@ private val SMS_BODY_AVLYST = """
 private val SMS_BODY_REFERAT = """
     {mottaker} har vært i dialogmøte med Nav i forbindelse med
     sykefraværet til en av deres ansatte.
+    
+     Referatet er nå tilgjengelig.
 
      Du kan lese referatet i {mottaker} sin innboks i Altinn, eller ved å logge inn på Min side arbeidsgiver hos Nav.
 

--- a/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/journalforing/DialogmoteVarselJournalforingCronjobTest.kt
@@ -466,12 +466,17 @@ class DialogmoteVarselJournalforingCronjobTest {
             personIdent = UserConstants.ARBEIDSTAKER_FNR,
             virksomhetsnummer = UserConstants.VIRKSOMHETSNUMMER_EREG_FAILS.value,
         )
+        val eregClientApiMock = mockk<EregClient>()
+        coEvery {
+            eregClientApiMock.organisasjonVirksomhetsnavn(UserConstants.VIRKSOMHETSNUMMER_EREG_FAILS)
+        } returns null
 
         testApplication {
             val client = setupApiAndClient(
                 behandlerVarselService = behandlerVarselService,
                 altinnMock = altinnMock,
-                esyfovarselProducer = esyfovarselProducerMock
+                esyfovarselProducer = esyfovarselProducerMock,
+                eregClient = eregClientApiMock,
             )
             client.postMote(validToken, newDialogmoteDTO)
         }

--- a/src/test/kotlin/no/nav/syfo/dialogmote/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmote/VarselServiceTest.kt
@@ -23,6 +23,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import no.nav.syfo.infrastructure.client.dokumentporten.DokumentportenClient
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 
 class VarselServiceTest {
 
@@ -31,6 +32,7 @@ class VarselServiceTest {
     private val behandlerVarselService = mockk<BehandlerVarselService>()
     private val altinnClient = mockk<AltinnClient>()
     private val oppfolgingstilfelleClient = mockk<OppfolgingstilfelleClient>()
+    private val eregClient = mockk<EregClient>()
     private val anyOppfolgingstilfelle = Oppfolgingstilfelle(
         start = LocalDate.now().minusDays(10),
         end = LocalDate.now().plusDays(10),
@@ -45,6 +47,7 @@ class VarselServiceTest {
         isAltinnSendingEnabled = true,
         dokumentportenClient = mockk<DokumentportenClient>(relaxed = true),
         isDokumentportenSendingEnabled = true,
+        eregClient = eregClient,
     )
 
     @BeforeEach
@@ -54,11 +57,13 @@ class VarselServiceTest {
         clearMocks(behandlerVarselService)
         clearMocks(altinnClient)
         clearMocks(oppfolgingstilfelleClient)
+        clearMocks(eregClient)
 
         justRun { arbeidstakerVarselService.sendVarsel(any(), any(), any(), any(), any()) }
         justRun { narmesteLederVarselService.sendVarsel(any(), any(), any()) }
         justRun { behandlerVarselService.sendVarsel(any(), any(), any(), any(), any(), any(), any(), any()) }
         justRun { altinnClient.sendToVirksomhet(any()) }
+        coEvery { eregClient.organisasjonVirksomhetsnavn(any()) } returns null
     }
 
     @Test

--- a/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
@@ -68,7 +68,7 @@ class VarselInstruksTest {
         )
 
         assertEquals(HendelseType.AG_VARSEL_ALTINN_RESSURS, varselInstruks.type, scenario)
-        assertEquals("DIALOGMOTE", varselInstruks.kilde, scenario)
+        assertEquals("isdialogmote", varselInstruks.kilde, scenario)
         assertEquals(forventning.epostTittel, varselInstruks.notifikasjonInnhold.epostTittel, scenario)
         assertEquals(forventning.varselTekst, varselInstruks.notifikasjonInnhold.varselTekst, scenario)
         assertContains(varselInstruks.notifikasjonInnhold.epostBody, forventetMottaker, message = scenario)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
@@ -69,20 +69,32 @@ class VarselInstruksTest {
 
         assertEquals(HendelseType.AG_VARSEL_ALTINN_RESSURS, varselInstruks.type, scenario)
         assertEquals("isdialogmote", varselInstruks.kilde, scenario)
-        assertEquals(forventning.epostTittel, varselInstruks.notifikasjonInnhold.epostTittel, scenario)
+        assertEquals(
+            forventning.epostTittelTemplate.withMottaker(forventetMottaker),
+            varselInstruks.notifikasjonInnhold.epostTittel,
+            scenario,
+        )
         assertEquals(forventning.varselTekst, varselInstruks.notifikasjonInnhold.varselTekst, scenario)
+        assertEquals(
+            forventning.epostBodyTemplate.withMottaker(forventetMottaker),
+            varselInstruks.notifikasjonInnhold.epostBody,
+            scenario,
+        )
+        assertEquals(
+            forventning.smsTekstTemplate.withMottaker(forventetMottaker),
+            varselInstruks.notifikasjonInnhold.smsTekst,
+            scenario,
+        )
         assertContains(varselInstruks.notifikasjonInnhold.epostBody, forventetMottaker, message = scenario)
         assertContains(varselInstruks.notifikasjonInnhold.smsTekst, forventetMottaker, message = scenario)
-        forventning.epostFragmenter.forEach {
-            assertContains(varselInstruks.notifikasjonInnhold.epostBody, it, message = scenario)
-        }
-        forventning.smsFragmenter.forEach {
-            assertContains(varselInstruks.notifikasjonInnhold.smsTekst, it, message = scenario)
-        }
+        assertFalse(varselInstruks.notifikasjonInnhold.epostTittel.contains("{mottaker}"), scenario)
         assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("{mottaker}"), scenario)
         assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("{mottaker}"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.varselTekst.contains("{mottaker}"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.epostTittel.contains("null"), scenario)
         assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("null"), scenario)
         assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("null"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.varselTekst.contains("null"), scenario)
     }
 
     private fun scenarioBeskrivelse(
@@ -93,64 +105,42 @@ class VarselInstruksTest {
 
     private data class VarselInstruksForventning(
         val varselType: MotedeltakerVarselType,
-        val epostTittel: String,
+        val epostTittelTemplate: String,
         val varselTekst: String,
-        val epostFragmenter: List<String>,
-        val smsFragmenter: List<String>,
+        val epostBodyTemplate: String,
+        val smsTekstTemplate: String,
     )
+
+    private fun String.withMottaker(mottaker: String): String = replace("{mottaker}", mottaker)
 
     private val forventninger = listOf(
         VarselInstruksForventning(
             varselType = MotedeltakerVarselType.INNKALT,
-            epostTittel = "Innkalling til dialogmøte med Nav",
-            varselTekst = "Innkalling til dialogmøte med Nav",
-            epostFragmenter = listOf(
-                "er innkalt til dialogmøte med Nav",
-                "Du kan lese innkallingen",
-            ),
-            smsFragmenter = listOf(
-                "er innkalt til dialogmøte med Nav",
-                "Du kan lese innkallingen",
-            ),
+            epostTittelTemplate = EMAIL_TITTEL_INNKALT,
+            varselTekst = VARSEL_TEKST_INNKALT,
+            epostBodyTemplate = EMAIL_BODY_INNKALT,
+            smsTekstTemplate = SMS_BODY_INNKALT,
         ),
         VarselInstruksForventning(
             varselType = MotedeltakerVarselType.NYTT_TID_STED,
-            epostTittel = "Dialogmøte med Nav er endret",
-            varselTekst = "Dialogmøte med Nav er endret",
-            epostFragmenter = listOf(
-                "Nav har endret tidspunktet eller stedet for dialogmøtet.",
-                "Du kan lese endringen",
-            ),
-            smsFragmenter = listOf(
-                "Nav har endret tidspunktet eller stedet for dialogmøtet.",
-                "Du kan lese endringen",
-            ),
+            epostTittelTemplate = EMAIL_TITTEL_NYTT_TID_STED,
+            varselTekst = VARSEL_TEKST_EMAIL_TITTEL_NYTT_TID_STED,
+            epostBodyTemplate = EMAIL_BODY_NYTT_TID_STED,
+            smsTekstTemplate = SMS_BODY_NYTT_TID_STED,
         ),
         VarselInstruksForventning(
             varselType = MotedeltakerVarselType.AVLYST,
-            epostTittel = "Dialogmøte med Nav er avlyst",
-            varselTekst = "Dialogmøte med Nav er avlyst",
-            epostFragmenter = listOf(
-                "Dialogmøtet har blitt avlyst.",
-                "Du kan lese avlysningen",
-            ),
-            smsFragmenter = listOf(
-                "Dialogmøtet har blitt avlyst.",
-                "Du kan lese avlysningen",
-            ),
+            epostTittelTemplate = EMAIL_TITTEL_AVLYST,
+            varselTekst = VARSEL_TEKST_AVLYST,
+            epostBodyTemplate = EMAIL_BODY_AVLYST,
+            smsTekstTemplate = SMS_BODY_AVLYST,
         ),
         VarselInstruksForventning(
             varselType = MotedeltakerVarselType.REFERAT,
-            epostTittel = "Referat fra dialogmøte med Nav",
-            varselTekst = "Referat fra dialogmøte med Nav",
-            epostFragmenter = listOf(
-                "har vært i dialogmøte med Nav",
-                "Du kan lese referatet",
-            ),
-            smsFragmenter = listOf(
-                "har vært i dialogmøte med Nav",
-                "Du kan lese referatet",
-            ),
+            epostTittelTemplate = EMAIL_TITTEL_REFERAT,
+            varselTekst = VARSEL_TEKST_REFERAT,
+            epostBodyTemplate = EMAIL_BODY_REFERAT,
+            smsTekstTemplate = SMS_BODY_REFERAT,
         ),
     )
 }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.infrastructure.client.dokumentporten
 
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
@@ -8,42 +9,148 @@ import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
 import org.junit.jupiter.api.Test
 
 class VarselInstruksTest {
-    @Test
-    fun `opprettForVarselType bruker virksomhetsdata i epost og sms`() {
-        val virksomhetsnummer = Virksomhetsnummer("123456785")
-        val virksomhetsnavn = EregVirksomhetsnavn("Testbedrift AS")
+    private val virksomhetsnummer = Virksomhetsnummer("123456785")
+    private val virksomhetsnavn = EregVirksomhetsnavn("Testbedrift AS")
 
+    @Test
+    fun `forventninger dekker alle MotedeltakerVarselType`() {
+        val varselTyperIForventninger = forventninger.map { it.varselType }
+        val alleVarselTyper = MotedeltakerVarselType.entries
+
+        assertEquals(alleVarselTyper.size, varselTyperIForventninger.size)
+        assertEquals(alleVarselTyper.toSet(), varselTyperIForventninger.toSet())
+    }
+
+    @Test
+    fun `opprettForVarselType oppretter forventet innhold med virksomhetsnavn`() {
+        val mottaker = "Testbedrift AS (${virksomhetsnummer.value})"
+
+        forventninger.forEach { forventning ->
+            assertVarselInstruks(
+                scenario = scenarioBeskrivelse(
+                    varselType = forventning.varselType,
+                    medVirksomhetsnavn = true,
+                ),
+                forventning = forventning,
+                virksomhetsnavn = virksomhetsnavn,
+                forventetMottaker = mottaker,
+            )
+        }
+    }
+
+    @Test
+    fun `opprettForVarselType oppretter forventet innhold uten virksomhetsnavn`() {
+        val mottaker = "Virksomhet med orgnummer ${virksomhetsnummer.value}"
+
+        forventninger.forEach { forventning ->
+            assertVarselInstruks(
+                scenario = scenarioBeskrivelse(
+                    varselType = forventning.varselType,
+                    medVirksomhetsnavn = false,
+                ),
+                forventning = forventning,
+                virksomhetsnavn = null,
+                forventetMottaker = mottaker,
+            )
+        }
+    }
+
+    private fun assertVarselInstruks(
+        scenario: String,
+        forventning: VarselInstruksForventning,
+        virksomhetsnavn: EregVirksomhetsnavn?,
+        forventetMottaker: String,
+    ) {
         val varselInstruks = VarselInstruks.opprettForVarselType(
-            varselType = MotedeltakerVarselType.INNKALT,
+            varselType = forventning.varselType,
             virksomhetsnummer = virksomhetsnummer,
             virksomhetsnavn = virksomhetsnavn,
         )
 
-        assertContains(varselInstruks.notifikasjonInnhold.epostBody, "Testbedrift AS (${virksomhetsnummer.value})")
-        assertContains(varselInstruks.notifikasjonInnhold.smsTekst, "Testbedrift AS (${virksomhetsnummer.value})")
-        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeName$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeNumber$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeName$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeNumber$"))
+        assertEquals(HendelseType.AG_VARSEL_ALTINN_RESSURS, varselInstruks.type, scenario)
+        assertEquals("DIALOGMOTE", varselInstruks.kilde, scenario)
+        assertEquals(forventning.epostTittel, varselInstruks.notifikasjonInnhold.epostTittel, scenario)
+        assertEquals(forventning.varselTekst, varselInstruks.notifikasjonInnhold.varselTekst, scenario)
+        assertContains(varselInstruks.notifikasjonInnhold.epostBody, forventetMottaker, message = scenario)
+        assertContains(varselInstruks.notifikasjonInnhold.smsTekst, forventetMottaker, message = scenario)
+        forventning.epostFragmenter.forEach {
+            assertContains(varselInstruks.notifikasjonInnhold.epostBody, it, message = scenario)
+        }
+        forventning.smsFragmenter.forEach {
+            assertContains(varselInstruks.notifikasjonInnhold.smsTekst, it, message = scenario)
+        }
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("{mottaker}"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("{mottaker}"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("null"), scenario)
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("null"), scenario)
     }
 
-    @Test
-    fun `opprettForVarselType bruker tom streng nar virksomhetsnavn er null`() {
-        val virksomhetsnummer = Virksomhetsnummer("123456785")
+    private fun scenarioBeskrivelse(
+        varselType: MotedeltakerVarselType,
+        medVirksomhetsnavn: Boolean,
+    ): String =
+        "Scenario[varselType=$varselType, virksomhetsnavn=${if (medVirksomhetsnavn) "med" else "uten"}]"
 
-        val varselInstruks = VarselInstruks.opprettForVarselType(
+    private data class VarselInstruksForventning(
+        val varselType: MotedeltakerVarselType,
+        val epostTittel: String,
+        val varselTekst: String,
+        val epostFragmenter: List<String>,
+        val smsFragmenter: List<String>,
+    )
+
+    private val forventninger = listOf(
+        VarselInstruksForventning(
+            varselType = MotedeltakerVarselType.INNKALT,
+            epostTittel = "Innkalling til dialogmøte med Nav",
+            varselTekst = "Innkalling til dialogmøte med Nav",
+            epostFragmenter = listOf(
+                "er innkalt til dialogmøte med Nav",
+                "Du kan lese innkallingen",
+            ),
+            smsFragmenter = listOf(
+                "er innkalt til dialogmøte med Nav",
+                "Du kan lese innkallingen",
+            ),
+        ),
+        VarselInstruksForventning(
+            varselType = MotedeltakerVarselType.NYTT_TID_STED,
+            epostTittel = "Dialogmøte med Nav er endret",
+            varselTekst = "Dialogmøte med Nav er endret",
+            epostFragmenter = listOf(
+                "Nav har endret tidspunktet eller stedet for dialogmøtet.",
+                "Du kan lese endringen",
+            ),
+            smsFragmenter = listOf(
+                "Nav har endret tidspunktet eller stedet for dialogmøtet.",
+                "Du kan lese endringen",
+            ),
+        ),
+        VarselInstruksForventning(
+            varselType = MotedeltakerVarselType.AVLYST,
+            epostTittel = "Dialogmøte med Nav er avlyst",
+            varselTekst = "Dialogmøte med Nav er avlyst",
+            epostFragmenter = listOf(
+                "Dialogmøtet har blitt avlyst.",
+                "Du kan lese avlysningen",
+            ),
+            smsFragmenter = listOf(
+                "Dialogmøtet har blitt avlyst.",
+                "Du kan lese avlysningen",
+            ),
+        ),
+        VarselInstruksForventning(
             varselType = MotedeltakerVarselType.REFERAT,
-            virksomhetsnummer = virksomhetsnummer,
-            virksomhetsnavn = null,
-        )
-
-        assertContains(varselInstruks.notifikasjonInnhold.epostBody, "Virksomhet med orgnummer ${virksomhetsnummer.value}")
-        assertContains(varselInstruks.notifikasjonInnhold.smsTekst, "Virksomhet med orgnummer ${virksomhetsnummer.value}")
-        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("null"))
-        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("null"))
-        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeName$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeNumber$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeName$"))
-        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeNumber$"))
-    }
+            epostTittel = "Referat fra dialogmøte med Nav",
+            varselTekst = "Referat fra dialogmøte med Nav",
+            epostFragmenter = listOf(
+                "har vært i dialogmøte med Nav",
+                "Du kan lese referatet",
+            ),
+            smsFragmenter = listOf(
+                "har vært i dialogmøte med Nav",
+                "Du kan lese referatet",
+            ),
+        ),
+    )
 }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/client/dokumentporten/VarselInstruksTest.kt
@@ -1,0 +1,49 @@
+package no.nav.syfo.infrastructure.client.dokumentporten
+
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.domain.dialogmote.MotedeltakerVarselType
+import no.nav.syfo.infrastructure.client.ereg.EregVirksomhetsnavn
+import org.junit.jupiter.api.Test
+
+class VarselInstruksTest {
+    @Test
+    fun `opprettForVarselType bruker virksomhetsdata i epost og sms`() {
+        val virksomhetsnummer = Virksomhetsnummer("123456785")
+        val virksomhetsnavn = EregVirksomhetsnavn("Testbedrift AS")
+
+        val varselInstruks = VarselInstruks.opprettForVarselType(
+            varselType = MotedeltakerVarselType.INNKALT,
+            virksomhetsnummer = virksomhetsnummer,
+            virksomhetsnavn = virksomhetsnavn,
+        )
+
+        assertContains(varselInstruks.notifikasjonInnhold.epostBody, "Testbedrift AS (${virksomhetsnummer.value})")
+        assertContains(varselInstruks.notifikasjonInnhold.smsTekst, "Testbedrift AS (${virksomhetsnummer.value})")
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeName$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeNumber$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeName$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeNumber$"))
+    }
+
+    @Test
+    fun `opprettForVarselType bruker tom streng nar virksomhetsnavn er null`() {
+        val virksomhetsnummer = Virksomhetsnummer("123456785")
+
+        val varselInstruks = VarselInstruks.opprettForVarselType(
+            varselType = MotedeltakerVarselType.REFERAT,
+            virksomhetsnummer = virksomhetsnummer,
+            virksomhetsnavn = null,
+        )
+
+        assertContains(varselInstruks.notifikasjonInnhold.epostBody, "Virksomhet med orgnummer ${virksomhetsnummer.value}")
+        assertContains(varselInstruks.notifikasjonInnhold.smsTekst, "Virksomhet med orgnummer ${virksomhetsnummer.value}")
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("null"))
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("null"))
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeName$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.epostBody.contains("\$reporteeNumber$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeName$"))
+        assertFalse(varselInstruks.notifikasjonInnhold.smsTekst.contains("\$reporteeNumber$"))
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -20,6 +20,10 @@ fun Application.testApiModule(
     behandlerVarselService: BehandlerVarselService = mockk(),
     altinnMock: ICorrespondenceAgencyExternalBasic = mockk(),
     esyfovarselProducer: EsyfovarselProducer = mockk(relaxed = true),
+    eregClient: EregClient = EregClient(
+        baseUrl = externalMockEnvironment.environment.eregUrl,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    ),
 ) {
     val dialogmotestatusService = DialogmotestatusService(
         oppfolgingstilfelleClient = externalMockEnvironment.oppfolgingstilfelleClient,
@@ -76,11 +80,6 @@ fun Application.testApiModule(
         syfomotebehovBaseUrl = externalMockEnvironment.environment.syfomotebehovUrl,
         httpClient = externalMockEnvironment.mockHttpClient,
     )
-    val eregClient = EregClient(
-        baseUrl = externalMockEnvironment.environment.eregUrl,
-        httpClient = externalMockEnvironment.mockHttpClient,
-    )
-
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
         esyfovarselProducer = esyfovarselProducer,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -6,6 +6,7 @@ import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondence
 import no.nav.syfo.api.apiModule
 import no.nav.syfo.application.*
 import no.nav.syfo.infrastructure.client.behandlendeenhet.BehandlendeEnhetClient
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 import no.nav.syfo.infrastructure.client.motebehov.MotebehovClient
 import no.nav.syfo.infrastructure.client.narmesteleder.NarmesteLederClient
 import no.nav.syfo.infrastructure.client.pdfgen.PdfGenClient
@@ -75,6 +76,10 @@ fun Application.testApiModule(
         syfomotebehovBaseUrl = externalMockEnvironment.environment.syfomotebehovUrl,
         httpClient = externalMockEnvironment.mockHttpClient,
     )
+    val eregClient = EregClient(
+        baseUrl = externalMockEnvironment.environment.eregUrl,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
 
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
@@ -97,6 +102,7 @@ fun Application.testApiModule(
         narmesteLederClient = narmesteLederClient,
         dokumentportenClient = dokumentportenClient,
         motebehovClient = motebehovClient,
+        eregClient = eregClient,
         pdfRepository = externalMockEnvironment.pdfRepository,
         moteRepository = externalMockEnvironment.moteRepository,
         transactionManager = externalMockEnvironment.transactionManager,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiUtils.kt
@@ -19,6 +19,7 @@ import no.nav.syfo.api.endpoints.dialogmoteApiV2Basepath
 import no.nav.syfo.application.BehandlerVarselService
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.dialogmote.Dialogmote
+import no.nav.syfo.infrastructure.client.ereg.EregClient
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.EsyfovarselProducer
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -28,6 +29,10 @@ fun ApplicationTestBuilder.setupApiAndClient(
     behandlerVarselService: BehandlerVarselService = mockk(),
     altinnMock: ICorrespondenceAgencyExternalBasic = mockk(),
     esyfovarselProducer: EsyfovarselProducer = mockk(relaxed = true),
+    eregClient: EregClient = EregClient(
+        baseUrl = ExternalMockEnvironment.getInstance().environment.eregUrl,
+        httpClient = ExternalMockEnvironment.getInstance().mockHttpClient,
+    ),
 ): HttpClient {
     application {
         testApiModule(
@@ -35,6 +40,7 @@ fun ApplicationTestBuilder.setupApiAndClient(
             behandlerVarselService = behandlerVarselService,
             altinnMock = altinnMock,
             esyfovarselProducer = esyfovarselProducer,
+            eregClient = eregClient,
         )
     }
     val client = createClient {


### PR DESCRIPTION
## Sammendrag
- Legger til varselinstruks for Dokumentporten når nærmeste leder mangler
- Bruker virksomhetsnavn fra Ereg i varseltekst der det finnes
- Utvider testdekning for VarselInstruks på alle varseltyper og mottakerscenarioer

## Issue
Ingen issue koblet.

## Verifisering
- ./gradlew --no-daemon build

## Merknader
- Kryssmodell-inspeksjon av testutbedringen: 😊 ingen blokkere.